### PR TITLE
fix/ci: update cake version and set JetBrains.ReSharper.CommandLineTools version

### DIFF
--- a/CakeHelperScripts/InspectCode.cake
+++ b/CakeHelperScripts/InspectCode.cake
@@ -1,4 +1,4 @@
-#tool nuget:?package=JetBrains.ReSharper.CommandLineTools
+#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2018.1.3
 #addin Cake.Issues
 #addin Cake.Issues.InspectCode
 

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.27.2" />
+    <package id="Cake" version="0.30.0" />
 </packages>


### PR DESCRIPTION
**Change**
- Cake script older package (v0.27.2) is not working (not sure why) that's why CI is not running properly. Upgrading the cake version fixes the issue.
- Newer NuGet package for JetBrains.ReSharper.CommandLineTools is reporting suppressed resharper rules as suggestions/warning, so setting it to an older version. 
