### PR TITLE
Remove x86 support for android.

### DIFF
--- a/CakeHelperScripts/NativeScriptDownloader.cake
+++ b/CakeHelperScripts/NativeScriptDownloader.cake
@@ -3,10 +3,8 @@ var ANDROID_DIR_NAME = "SafeApp.AppBindings.Android";
 var IOS_DIR_NAME = "SafeApp.AppBindings.iOS";
 var DESKTOP_DIR_NAME = "SafeApp.AppBindings.Desktop";
 
-var ANDROID_X86 = "android-x86";
 var ANDROID_ARMEABI_V7A = "android-armeabiv7a";
 var ANDROID_ARCHITECTURES = new string[] {
-  ANDROID_X86,
   ANDROID_ARMEABI_V7A
 };
 var IOS_ARCHITECTURES = new string[] {
@@ -131,10 +129,8 @@ Task("UnZip-Libs")
           {
             platformOutputDirectory.Append("/non-mock");
           }
-
-          if(target.Equals(ANDROID_X86))
-            platformOutputDirectory.Append("/x86");
-          else if(target.Equals(ANDROID_ARMEABI_V7A))
+          
+          if(target.Equals(ANDROID_ARMEABI_V7A))
             platformOutputDirectory.Append("/armeabi-v7a");
 
           Unzip(zip, platformOutputDirectory.ToString());

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # safe_app_csharp
 
-|NuGet Package|CI - NetCore master|
-|:-----------:|:-----------------:|
-|[![NuGet](https://img.shields.io/nuget/v/MaidSafe.SafeApp.svg)](https://www.nuget.org/packages/MaidSafe.SafeApp)|[![Build status](https://ci.appveyor.com/api/projects/status/x3m722rvosw2coao/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-app-csharp/branch/master)|
+| NuGet Package                                                                                                    | CI - NetCore master                                                                                                                                                               |
+| :--------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| [![NuGet](https://img.shields.io/nuget/v/MaidSafe.SafeApp.svg)](https://www.nuget.org/packages/MaidSafe.SafeApp) | [![Build status](https://ci.appveyor.com/api/projects/status/x3m722rvosw2coao/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-app-csharp/branch/master) |
 
 safe_app CSharp Library. Currently supports
-- Xamarin.Android ( >=4.1.2. ABI: armeabi-v7a, x86)
+- Xamarin.Android ( >=4.1.2. ABI: armeabi-v7a)
 - Xamarin.iOS ( >= 1.0, ABI: ARM64, x64)
 - netstandard1.3 (for usage via portable libs)
 - netcoreapp1.0 (for use via NET Core targets. Runtime support limited to x64)
 - netframework46 (for use via classic NET Framework targets. Platform support limited to x64)
 
 | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
-|:----:|:----:|:----:|
+| :--------------------------------------: | :-----------------------------------------: | :--------------------------------------------: |
 
 # TODO
 - [x] Extend Native API Scope to full Alpha-2 client APIs.

--- a/SafeApp.AppBindings.Android/Android.targets
+++ b/SafeApp.AppBindings.Android/Android.targets
@@ -18,6 +18,8 @@
   </Choose>
   <ItemGroup>
     <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\armeabi-v7a\libsafe_app.so" />
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\x86\libsafe_app.so" />
   </ItemGroup>
+  <Target Name="CheckProjectPlatform" BeforeTargets="PrepareForBuild">
+    <Error Condition="'$(AndroidSupportedAbis)' != 'armeabi-v7a'" Text="SafeApp package currently supports armeabi-v7a. Please set the Project Platform to armeabi-v7a." />
+  </Target>
 </Project>

--- a/SafeApp.Tests.Android/SafeApp.Tests.Android.csproj
+++ b/SafeApp.Tests.Android/SafeApp.Tests.Android.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Xamarin.Forms.2.5.0.122203\build\netstandard1.0\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.2.5.0.122203\build\netstandard1.0\Xamarin.Forms.props')" />
+<Project ToolsVersion="4.0" DefaultTargets="Build" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -16,7 +17,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-    <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />
     <JavaMaximumHeapSize>
@@ -158,9 +159,6 @@
     <AndroidNativeLibrary Include="..\SafeApp.AppBindings.Android\lib\mock\armeabi-v7a\libsafe_app.so">
       <Link>lib\armeabi-v7a\libsafe_app.so</Link>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="..\SafeApp.AppBindings.Android\lib\mock\x86\libsafe_app.so">
-      <Link>lib\x86\libsafe_app.so</Link>
-    </AndroidNativeLibrary>
     <AndroidAsset Include="..\SafeApp.Tests\log.toml">
       <Link>Assets\log.toml</Link>
     </AndroidAsset>
@@ -244,6 +242,7 @@
   <Import Project="..\packages\Xamarin.Android.Support.Design.26.1.0.1\build\MonoAndroid80\Xamarin.Android.Support.Design.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Design.26.1.0.1\build\MonoAndroid80\Xamarin.Android.Support.Design.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.v7.MediaRouter.26.1.0.1\build\MonoAndroid80\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.MediaRouter.26.1.0.1\build\MonoAndroid80\Xamarin.Android.Support.v7.MediaRouter.targets')" />
   <Import Project="..\packages\Xamarin.Forms.2.5.0.122203\build\netstandard1.0\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.5.0.122203\build\netstandard1.0\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.5.0.122203\build\netstandard1.0\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.2.5.0.122203\build\netstandard1.0\Xamarin.Forms.props')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
      Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Fixes: #31 

**Changes**
- Remove from cake files (download and unzipping x86 android native libraries)
- Update project structure to not include x86 libs
- Update readme file
- Update nuspec file (used for NuGet packaging)