### PR TITLE
Add Support for Android x86_64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.userprefs
 *.GhostDoc.xml
 .vs/
+.vscode
 
 # ignore Xamarin.Android Resource.Designer.cs files
 **/*.Droid/**/[Rr]esource.[Dd]esigner.cs

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ bld/
 [Bb]uild[Ll]og.*
 
 # NUNIT
-TestResult.xml
+**/*TestResult.xml
 *.VisualState.xml
 
 # Build Results of an ATL Project

--- a/CakeHelperScripts/AndroidTest.cake
+++ b/CakeHelperScripts/AndroidTest.cake
@@ -1,0 +1,128 @@
+#load "Utility.cake"
+
+#addin nuget:?package=Cake.Android.Adb&version=3.0.0
+#addin nuget:?package=Cake.Android.AvdManager&version=1.0.3
+#addin nuget:?package=Cake.FileHelpers
+
+var ANDROID_TEST_PROJ = "SafeApp.Tests.Android/SafeApp.Tests.Android.csproj";
+var ANDROID_TESTS_RESULT_PATH = "SafeApp.Tests.Android/AndroidTestResult.xml";
+var ANDROID_AVD = "SafeAppEmulator";
+var ANDROID_PKG_NAME = "SafeApp.Tests.Android";
+var ANDROID_EMU_TARGET = EnvironmentVariable("ANDROID_EMU_TARGET") ?? "system-images;android-28;google_apis;x86_64";
+var ANDROID_EMU_DEVICE = EnvironmentVariable("ANDROID_EMU_DEVICE") ?? "Nexus 6P";
+var ANDROID_TCP_LISTEN_HOST = System.Net.IPAddress.Any;
+var ANDROID_TCP_LISTEN_PORT = 10500;
+var ANDROID_HOME = EnvironmentVariable("ANDROID_HOME");
+
+Task("Build-Android-Test-Project")
+    .IsDependentOn("Restore-NuGet")
+    .Does(() => {
+    // Build the app in debug mode
+    // needs to be debug so unit tests get discovered
+    MSBuild(ANDROID_TEST_PROJ, c =>
+    {
+        c.Configuration = "Debug";
+        c.Targets.Clear();
+        c.Targets.Add("Rebuild");
+        c.SetVerbosity(Verbosity.Minimal);
+    });
+});
+
+Task("Run-Android-Tests")
+    .IsDependentOn("Build-Android-Test-Project")
+    .Does(() => {
+    if (EnvironmentVariable("ANDROID_SKIP_AVD_CREATE") == null)
+    {
+        var avdSettings = new AndroidAvdManagerToolSettings { SdkRoot = ANDROID_HOME };
+
+        // Create the AVD if necessary
+        Information("Creating AVD if necessary: {0}...", ANDROID_AVD);
+        if (!AndroidAvdListAvds(avdSettings).Any(a => a.Name == ANDROID_AVD))
+            AndroidAvdCreate(ANDROID_AVD, ANDROID_EMU_TARGET, ANDROID_EMU_DEVICE, force: true, settings: avdSettings);
+    }
+    // We need to find `emulator` and the best way is to try within a specified ANDROID_HOME
+    var emulatorExt = IsRunningOnWindows() ? ".exe" : "";
+    string emulatorPath = "emulator" + emulatorExt;
+
+    if (ANDROID_HOME != null)
+    {
+        var andHome = new DirectoryPath(ANDROID_HOME);
+        if (DirectoryExists(andHome))
+        {
+            emulatorPath = MakeAbsolute(andHome.Combine("tools").CombineWithFilePath("emulator" + emulatorExt)).FullPath;
+            if (!FileExists(emulatorPath))
+                emulatorPath = MakeAbsolute(andHome.Combine("emulator").CombineWithFilePath("emulator" + emulatorExt)).FullPath;
+            if (!FileExists(emulatorPath))
+                emulatorPath = "emulator" + emulatorExt;
+        }
+    }
+
+    // Start up the emulator by name
+    var emu = StartAndReturnProcess(emulatorPath, new ProcessSettings
+    {
+        Arguments = $"-avd {ANDROID_AVD} -gpu auto -noaudio"
+    });
+    var adbSettings = new AdbToolSettings { SdkRoot = ANDROID_HOME };
+
+    // Keep checking adb for an emulator with an AVD name matching the one we just started
+    var emuSerial = string.Empty;
+    for (int i = 0; i < 100; i++)
+    {
+        foreach (var device in AdbDevices(adbSettings).Where(d => d.Serial.StartsWith("emulator-")))
+        {
+            if (AdbGetAvdName(device.Serial).Equals(ANDROID_AVD, StringComparison.OrdinalIgnoreCase))
+            {
+                emuSerial = device.Serial;
+                break;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(emuSerial))
+            break;
+        else
+            System.Threading.Thread.Sleep(1000);
+    }
+
+    Information("Matched ADB Serial: {0}", emuSerial);
+    adbSettings = new AdbToolSettings { SdkRoot = ANDROID_HOME, Serial = emuSerial };
+
+    // Wait for the emulator to enter a 'booted' state
+    AdbWaitForEmulatorToBoot(TimeSpan.FromSeconds(100), adbSettings);
+    Information("Emulator finished booting.");
+
+    // Try uninstalling the existing package (if installed)
+    try
+    {
+        AdbUninstall(ANDROID_PKG_NAME, false, adbSettings);
+        Information("Uninstalled old: {0}", ANDROID_PKG_NAME);
+    }
+    catch { }
+
+    // Use the Install target to push the app onto emulator
+    MSBuild(ANDROID_TEST_PROJ, c =>
+    {
+        c.Configuration = "Debug";
+        c.Properties["AdbTarget"] = new List<string> { "-s " + emuSerial };
+        c.Targets.Clear();
+        c.Targets.Add("Install");
+        c.SetVerbosity(Verbosity.Minimal);
+    });
+
+    //start the TCP Test results listener
+    Information("Started TCP Test Results Listener on port: {0}", ANDROID_TCP_LISTEN_PORT);
+    var tcpListenerTask = DownloadTcpTextAsync(ANDROID_TCP_LISTEN_HOST, ANDROID_TCP_LISTEN_PORT, ANDROID_TESTS_RESULT_PATH);
+
+    // Launch the app on the emulator
+    AdbShell($"am start -n {ANDROID_PKG_NAME}/{ANDROID_PKG_NAME}.MainActivity", adbSettings);
+
+    // // Wait for the test results to come back
+    Information("Waiting for tests...");
+    tcpListenerTask.Wait();
+
+    // Close emulator    
+    emu.Kill();
+
+})
+    .ReportError(exception => {
+    Information(exception.Message);
+});

--- a/CakeHelperScripts/DesktopTest.cake
+++ b/CakeHelperScripts/DesktopTest.cake
@@ -1,0 +1,47 @@
+
+// --------------------------------------------------------------------------------
+// Desktop Build and Test
+// --------------------------------------------------------------------------------
+
+var coreTestProject = File("SafeApp.Tests.Core/SafeApp.Tests.Core.csproj");
+var coreTestBin = Directory("SafeApp.Tests.Core/bin/Release");
+var Desktop_TESTS_RESULT_PATH = "SafeApp.Tests.Core/TestResults/DesktopTestResult.xml";
+
+Task("Build-Desktop-Project")
+  .IsDependentOn("Restore-NuGet")
+  .Does(() => {
+    var dotnetBuildArgument = string.Empty;
+    var osFamily = (int)Context.Environment.Platform.Family;
+    if(osFamily == 1)
+      dotnetBuildArgument = @"--runtime win10-x64";
+    else if(osFamily == 2)
+      dotnetBuildArgument = @"--runtime linux-x64";
+    else if (osFamily == 3)
+      dotnetBuildArgument = @"--runtime win-x64";
+    
+    DotNetCoreBuild(coreTestProject,
+    new DotNetCoreBuildSettings() {
+      Configuration = configuration,
+      ArgumentCustomization = args => args.Append(dotnetBuildArgument)
+      });
+  });
+
+Task("Run-Desktop-Tests")
+  .IsDependentOn("Build-Desktop-Project")
+  .Does(() => {
+      DotNetCoreTest(
+        coreTestProject.Path.FullPath,
+        new DotNetCoreTestSettings()
+        {
+          Configuration = configuration,
+          ArgumentCustomization = args => args.Append("--logger \"trx;LogFileName=DesktopTestResult.xml\"")
+        });
+  })
+  .Finally(() =>
+  {
+    if(AppVeyor.IsRunningOnAppVeyor)
+    {
+      var resultsFile = File(Desktop_TESTS_RESULT_PATH);
+      AppVeyor.UploadTestResults(resultsFile.Path.FullPath, AppVeyorTestResultsType.MSTest);
+    }
+  });

--- a/CakeHelperScripts/InspectCode.cake
+++ b/CakeHelperScripts/InspectCode.cake
@@ -1,6 +1,6 @@
 #tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2018.1.3
-#addin Cake.Issues
-#addin Cake.Issues.InspectCode
+#addin nuget:?package=Cake.Issues&version=0.6.0
+#addin nuget:?package=Cake.Issues.InspectCode&version=0.6.0
 
 var logPath = @"resharper-clt-output.xml";
 var buildDirectory = Directory(".");
@@ -25,6 +25,8 @@ Task("Analyze-Project-Report")
       InspectCodeIssuesFromFilePath(logPath),
       buildDirectory);
     
+    Information("InspectCode : {0} issues found.", issues.Count());
+
     if(issues.Count()>0) {
       foreach (var item in issues)
       {
@@ -34,8 +36,8 @@ Task("Analyze-Project-Report")
         else
           Information(issueMessage);
       }
-      if(AppVeyor.IsRunningOnAppVeyor)
-        throw new Exception("Build Failed : InspectCode issues found. Check message tab for details.");
+      
+      throw new Exception("Build Failed : InspectCode issues found.");
     }
     else {
       if(AppVeyor.IsRunningOnAppVeyor)

--- a/CakeHelperScripts/InspectCode.cake
+++ b/CakeHelperScripts/InspectCode.cake
@@ -24,10 +24,10 @@ Task("Analyze-Project-Report")
     var issues = ReadIssues(
       InspectCodeIssuesFromFilePath(logPath),
       buildDirectory);
-    
-    Information("InspectCode : {0} issues found.", issues.Count());
 
     if(issues.Count()>0) {
+      Information("InspectCode : {0} issues found.", issues.Count());
+      
       foreach (var item in issues)
       {
         var issueMessage = $"Priority: {item.PriorityName}, Details: {item.Message}, Line: {item.Line}, File: {item.AffectedFileRelativePath}";

--- a/CakeHelperScripts/NativeScriptDownloader.cake
+++ b/CakeHelperScripts/NativeScriptDownloader.cake
@@ -4,8 +4,10 @@ var IOS_DIR_NAME = "SafeApp.AppBindings.iOS";
 var DESKTOP_DIR_NAME = "SafeApp.AppBindings.Desktop";
 
 var ANDROID_ARMEABI_V7A = "android-armeabiv7a";
+var ANDROID_x86_64 = "android-x86_64";
 var ANDROID_ARCHITECTURES = new string[] {
-  ANDROID_ARMEABI_V7A
+  ANDROID_ARMEABI_V7A,
+	ANDROID_x86_64
 };
 var IOS_ARCHITECTURES = new string[] {
   "ios"
@@ -132,6 +134,8 @@ Task("UnZip-Libs")
           
           if(target.Equals(ANDROID_ARMEABI_V7A))
             platformOutputDirectory.Append("/armeabi-v7a");
+				  else if(target.Equals(ANDROID_x86_64))
+            platformOutputDirectory.Append("/x86_64");
 
           Unzip(zip, platformOutputDirectory.ToString());
 
@@ -141,7 +145,6 @@ Task("UnZip-Libs")
             if(aFile.Count > 0)
             DeleteFile(aFile.ToArray()[0].FullPath);
           }
-
         }
       }
     }

--- a/CakeHelperScripts/NativeScriptDownloader.cake
+++ b/CakeHelperScripts/NativeScriptDownloader.cake
@@ -7,7 +7,7 @@ var ANDROID_ARMEABI_V7A = "android-armeabiv7a";
 var ANDROID_x86_64 = "android-x86_64";
 var ANDROID_ARCHITECTURES = new string[] {
   ANDROID_ARMEABI_V7A,
-	ANDROID_x86_64
+  ANDROID_x86_64
 };
 var IOS_ARCHITECTURES = new string[] {
   "ios"
@@ -60,6 +60,16 @@ Task("Download-Libs")
 
         if(!DirectoryExists(targetDirectory))
           CreateDirectory(targetDirectory);
+        else
+        {
+          var existingNativeLibs = GetFiles(string.Format("{0}/*.zip", targetDirectory));
+          if(existingNativeLibs.Count > 0)
+          foreach(var lib in existingNativeLibs) 
+          {
+            if(!lib.GetFilename().ToString().Contains(TAG))
+              DeleteFile(lib.FullPath);
+          }
+        }
 
         Information("Downloading : {0}", mockZipFilename);
         if(!FileExists(mockZipSavePath))
@@ -134,7 +144,7 @@ Task("UnZip-Libs")
           
           if(target.Equals(ANDROID_ARMEABI_V7A))
             platformOutputDirectory.Append("/armeabi-v7a");
-				  else if(target.Equals(ANDROID_x86_64))
+          else if(target.Equals(ANDROID_x86_64))
             platformOutputDirectory.Append("/x86_64");
 
           Unzip(zip, platformOutputDirectory.ToString());
@@ -143,7 +153,7 @@ Task("UnZip-Libs")
           {
             var aFile = GetFiles(string.Format("{0}/*.a", platformOutputDirectory.ToString()));
             if(aFile.Count > 0)
-            DeleteFile(aFile.ToArray()[0].FullPath);
+              DeleteFile(aFile.ToArray()[0].FullPath);
           }
         }
       }

--- a/CakeHelperScripts/Utility.cake
+++ b/CakeHelperScripts/Utility.cake
@@ -1,0 +1,48 @@
+#addin nuget:?package=Cake.FileHelpers
+using System.Net;
+using System.Net.Sockets;
+
+Func<IPAddress, int, string, Task> DownloadTcpTextAsync = (IPAddress TCP_LISTEN_HOST, int TCP_LISTEN_PORT, string RESULTS_PATH) => System.Threading.Tasks.Task.Run(() =>
+{
+    TcpListener server = null;
+    try
+    {
+        server = new TcpListener(TCP_LISTEN_HOST, TCP_LISTEN_PORT);
+        server.Start();
+        while (true)
+        {
+            TcpClient client = server.AcceptTcpClient();
+            NetworkStream stream = client.GetStream();
+            StreamReader data_in = new StreamReader(client.GetStream());
+            var result = data_in.ReadToEnd();
+            System.IO.File.AppendAllText(RESULTS_PATH, result);
+            client.Close();
+            break;
+        }
+    }
+    catch (SocketException e)
+    {
+        Information("SocketException: {0}", e);
+    }
+    finally
+    {
+        server.Stop();
+    }
+});
+
+void AnalyseResultFile(string FilePath)
+{
+    string line;
+    var file = new StreamReader(FilePath);
+    while ((line = file.ReadLine()) != null)
+    {
+        foreach (var word in line.Split(' '))
+        {
+            if (word == @"result=""Failed""")
+            {
+                throw new Exception("Tests Failed");
+            }
+        }
+    }
+    file.Close();
+}

--- a/CakeHelperScripts/iOSTest.cake
+++ b/CakeHelperScripts/iOSTest.cake
@@ -1,0 +1,78 @@
+#load "Utility.cake"
+
+#addin nuget:?package=Cake.AppleSimulator&Version=0.1.0
+#addin nuget:?package=Cake.FileHelpers
+#addin "Cake.Powershell"
+
+var IOS_SIM_NAME = EnvironmentVariable("IOS_SIM_NAME") ?? "iPhone X";
+var IOS_SIM_RUNTIME = EnvironmentVariable("IOS_SIM_RUNTIME") ?? "iOS 12.0";
+var IOS_TEST_PROJ = "SafeApp.Tests.iOS/SafeApp.Tests.iOS.csproj";
+var IOS_BUNDLE_ID = "net.maidsafe.SafeApp.Tests.iOS";
+var IOS_IPA_PATH = "SafeApp.Tests.iOS/bin/iPhoneSimulator/Release/SafeApp.Tests.iOS.app";
+var IOS_TESTS_RESULT_PATH = "SafeApp.Tests.iOS/iOSTestResult.xml";
+
+var IOS_TCP_LISTEN_HOST = System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName()).AddressList.First(f => f.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
+var IOS_TCP_LISTEN_PORT = 10500;
+
+Task("Build-iOS-Test-Project")
+    .Does(() => {
+    // Build the project (with ipa)
+    MSBuild(IOS_TEST_PROJ, c =>
+    {
+        c.Configuration = "Release";
+        c.Properties["Platform"] = new List<string> { "iPhoneSimulator" };
+        c.Properties["BuildIpa"] = new List<string> { "true" };
+        c.Targets.Clear();
+        c.Targets.Add("Rebuild");
+        c.SetVerbosity(Verbosity.Minimal);
+    });
+});
+
+Task("Run-iOS-Tests")
+    .IsDependentOn("Build-iOS-Test-Project")
+    .Does(() => {
+    // Look for a matching simulator on the system
+    var sim = ListAppleSimulators()
+        .First(s => (s.Availability.Contains("available") || s.Availability.Contains("booted")) &&
+           !s.Availability.Contains("unavailable") &&
+           s.Name == IOS_SIM_NAME && s.Runtime == IOS_SIM_RUNTIME);
+
+    // Boot the simulator
+    Information("Booting: {0} ({1} - {2})", sim.Name, sim.Runtime, sim.UDID);
+    if (!sim.State.ToLower().Contains("booted"))
+        BootAppleSimulator(sim.UDID);
+
+    // Wait for it to be booted
+    for (int i = 0; i < 100; i++)
+    {
+        if (ListAppleSimulators().Any(s => s.UDID == sim.UDID && s.State.ToLower().Contains("booted")))
+        {
+            break;
+        }
+        System.Threading.Thread.Sleep(1000);
+    }
+
+    // Install the IPA that was previously built
+    var ipaPath = new FilePath(IOS_IPA_PATH);
+    Information("Installing: {0}", ipaPath);
+    InstalliOSApplication(sim.UDID, MakeAbsolute(ipaPath).FullPath);
+
+    // Start our Test Results TCP listener
+    Information("Started TCP Test Results Listener on port: {0}", IOS_TCP_LISTEN_PORT);
+    var tcpListenerTask = DownloadTcpTextAsync(IOS_TCP_LISTEN_HOST, IOS_TCP_LISTEN_PORT, IOS_TESTS_RESULT_PATH);
+
+    // Launch the IPA
+    Information("Launching: {0}", IOS_BUNDLE_ID);
+    LaunchiOSApplication(sim.UDID, IOS_BUNDLE_ID);
+
+    // Wait for the TCP listener to get results
+    Information("Waiting for tests...");
+    tcpListenerTask.Wait();
+
+    // Close up simulators
+    Information("Closing Simulator");
+    ShutdownAllAppleSimulators();
+})
+    .ReportError(exception => {
+    Information(exception.Message);
+});

--- a/CakeHelperScripts/iOSTest.cake
+++ b/CakeHelperScripts/iOSTest.cake
@@ -73,6 +73,6 @@ Task("Run-iOS-Tests")
     Information("Closing Simulator");
     ShutdownAllAppleSimulators();
 })
-    .ReportError(exception => {
+.ReportError(exception => {
     Information(exception.Message);
 });

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 | [![NuGet](https://img.shields.io/nuget/v/MaidSafe.SafeApp.svg)](https://www.nuget.org/packages/MaidSafe.SafeApp) | [![Build status](https://ci.appveyor.com/api/projects/status/x3m722rvosw2coao/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-app-csharp/branch/master) |
 
 safe_app CSharp Library. Currently supports
-- Xamarin.Android ( >=4.1.2. ABI: armeabi-v7a)
+- Xamarin.Android ( >=4.1.2. ABI: armeabi-v7a, x86_64)
 - Xamarin.iOS ( >= 1.0, ABI: ARM64, x64)
 - netstandard1.3 (for usage via portable libs)
 - netcoreapp1.0 (for use via NET Core targets. Runtime support limited to x64)

--- a/SafeApp.AppBindings.Android/Android.targets
+++ b/SafeApp.AppBindings.Android/Android.targets
@@ -18,8 +18,6 @@
   </Choose>
   <ItemGroup>
     <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\armeabi-v7a\libsafe_app.so" />
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\x86_64\libsafe_app.so" />
   </ItemGroup>
-  <Target Name="CheckProjectPlatform" BeforeTargets="PrepareForBuild">
-    <Error Condition="'$(AndroidSupportedAbis)' != 'armeabi-v7a'" Text="SafeApp package currently supports armeabi-v7a. Please set the Project Platform to armeabi-v7a." />
-  </Target>
 </Project>

--- a/SafeApp.AppBindings.Android/SafeApp.AppBindings.Android.csproj
+++ b/SafeApp.AppBindings.Android/SafeApp.AppBindings.Android.csproj
@@ -73,10 +73,10 @@
     <ItemGroup>
       <NativeSafeAppLibs Include="lib\**\*.so" />
     </ItemGroup>
-    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'Windows_NT'" Command="cd.. &amp; powershell -ExecutionPolicy ByPass -File .\build.ps1 -Configuration Release -target UnZip-Libs">
+    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'Windows_NT'" Command="cd.. &amp; powershell -ExecutionPolicy ByPass -File .\build.ps1 -Configuration Release -target=UnZip-Libs --settings_skipverification=true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
-    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'UNIX'" Command="cd .. &amp;&amp; bash build.sh --Configuration=Release --target=Unzip-Libs">
+    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'UNIX'" Command="cd .. &amp;&amp; bash build.sh --Configuration=Release --target=Unzip-Libs --settings_skipverification=true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
   </Target>

--- a/SafeApp.AppBindings.Desktop/SafeApp.AppBindings.Desktop.csproj
+++ b/SafeApp.AppBindings.Desktop/SafeApp.AppBindings.Desktop.csproj
@@ -20,10 +20,10 @@
     <ItemGroup>
       <NativeSafeAppLibs Include="lib\**\*.*" />
     </ItemGroup>
-    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'Windows_NT'" Command="cd.. &amp; powershell -ExecutionPolicy ByPass -File .\build.ps1 -Configuration Release -target UnZip-Libs">
+    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'Windows_NT'" Command="cd.. &amp; powershell -ExecutionPolicy ByPass -File .\build.ps1 -Configuration Release -target=UnZip-Libs  --settings_skipverification=true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
-    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'UNIX'" Command="cd .. &amp;&amp; bash build.sh --Configuration=Release --target=Unzip-Libs">
+    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'UNIX'" Command="cd .. &amp;&amp; bash build.sh --Configuration=Release --target=Unzip-Libs  --settings_skipverification=true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
   </Target>

--- a/SafeApp.AppBindings.iOS/SafeApp.AppBindings.iOS.csproj
+++ b/SafeApp.AppBindings.iOS/SafeApp.AppBindings.iOS.csproj
@@ -68,10 +68,10 @@
     <ItemGroup>
       <NativeSafeAppLibs Include="lib\**\*.a" />
     </ItemGroup>
-    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'Windows_NT'" Command="cd.. &amp; powershell -ExecutionPolicy ByPass -File .\build.ps1 -Configuration Release -target UnZip-Libs">
+    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'Windows_NT'" Command="cd.. &amp; powershell -ExecutionPolicy ByPass -File .\build.ps1 -Configuration Release -target=UnZip-Libs  --settings_skipverification=true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
-    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'UNIX'" Command="cd .. &amp;&amp; bash build.sh --Configuration=Release --target=Unzip-Libs">
+    <Exec ConsoleToMSBuild="true" Condition="'@(NativeSafeAppLibs-&gt;Count())' == '0' AND '$(OS)' == 'UNIX'" Command="cd .. &amp;&amp; bash build.sh --Configuration=Release --target=Unzip-Libs  --settings_skipverification=true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
   </Target>

--- a/SafeApp.AppBindings.iOS/SafeApp.AppBindings.iOS.csproj
+++ b/SafeApp.AppBindings.iOS/SafeApp.AppBindings.iOS.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -12,7 +13,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>SafeApp.AppBindings</AssemblyName>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -22,7 +23,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>

--- a/SafeApp.MockAuthBindings.iOS/SafeApp.MockAuthBindings.iOS.csproj
+++ b/SafeApp.MockAuthBindings.iOS/SafeApp.MockAuthBindings.iOS.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -12,7 +13,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>SafeApp.MockAuthBindings</AssemblyName>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -22,7 +23,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>

--- a/SafeApp.Tests.Android/MainActivity.cs
+++ b/SafeApp.Tests.Android/MainActivity.cs
@@ -29,48 +29,54 @@ using NUnit.Runner.Services;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 
-namespace SafeApp.Tests.Android {
-  [Activity(
-    Label = "SafeApp.Tests.Android",
-    Icon = "@drawable/icon",
-    Theme = "@android:style/Theme.Holo.Light",
-    MainLauncher = true,
-    ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
-  // ReSharper disable once UnusedMember.Global
-  public class MainActivity : FormsApplicationActivity {
-    protected override void OnCreate(Bundle savedInstanceState) {
-      base.OnCreate(savedInstanceState);
+namespace SafeApp.Tests.Android
+{
+    [Activity(
+      Name = "SafeApp.Tests.Android.MainActivity",
+      Label = "SafeApp.Tests.Android",
+      Icon = "@drawable/icon",
+      Theme = "@android:style/Theme.Holo.Light",
+      MainLauncher = true,
+      ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    // ReSharper disable once UnusedMember.Global
+    public class MainActivity : FormsApplicationActivity
+    {
+        protected override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
 
-      Forms.Init(this, savedInstanceState);
+            Forms.Init(this, savedInstanceState);
 
-      // This will load all tests within the current project
-      var nunit = new App {
-        Options = new TestOptions {
-          // If True, the tests will run automatically when the app starts
-          // otherwise you must run them manually.
-          AutoRun = false
+            // This will load all tests within the current project
+            var nunit = new App
+            {
+                Options = new TestOptions
+                {
+                    // If True, the tests will run automatically when the app starts
+                    // otherwise you must run them manually.
+                    AutoRun = true,
 
-          // If True, the application will terminate automatically after running the tests.
-          //TerminateAfterExecution = true,
+                    // If True, the application will terminate automatically after running the tests.
+                    //TerminateAfterExecution = true,
 
-          // Information about the tcp listener host and port.
-          // For now, send result as XML to the listening server.
-          //TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),
+                    // Information about the tcp listener host and port.
+                    // For now, send result as XML to the listening server.
+                    TcpWriterParameters = new TcpWriterInfo("10.0.2.2", 10500)
 
-          // Creates a NUnit Xml result file on the host file system using PCLStorage library.
-          // CreateXmlResultFile = true,
+                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                    // CreateXmlResultFile = true,
 
-          // Choose a different path for the xml result file
-          // ResultFilePath = Path.Combine(Environment.ExternalStorageDirectory.Path, Environment.DirectoryDownloads, "Nunit", "Results.xml")
+                    // Choose a different path for the xml result file
+                    // ResultFilePath = Path.Combine(Environment.ExternalStorageDirectory.Path, Environment.DirectoryDownloads, "Nunit", "Results.xml")
+                }
+            };
+
+            // If you want to add tests in another assembly
+            //nunit.AddTestAssembly(typeof(MyTests).Assembly);
+
+            // Available options for testing
+
+            LoadApplication(nunit);
         }
-      };
-
-      // If you want to add tests in another assembly
-      //nunit.AddTestAssembly(typeof(MyTests).Assembly);
-
-      // Available options for testing
-
-      LoadApplication(nunit);
     }
-  }
 }

--- a/SafeApp.Tests.Android/MainActivity.cs
+++ b/SafeApp.Tests.Android/MainActivity.cs
@@ -1,27 +1,4 @@
-﻿// ***********************************************************************
-// Copyright (c) 2017 Charlie Poole
-//
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// ***********************************************************************
-
-using Android.App;
+﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
 using NUnit.Runner;

--- a/SafeApp.Tests.Android/SafeApp.Tests.Android.csproj
+++ b/SafeApp.Tests.Android/SafeApp.Tests.Android.csproj
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" 
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -16,8 +14,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-    <AndroidSupportedAbis>armeabi-v7a</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a,x86_64</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />
     <JavaMaximumHeapSize>
@@ -158,6 +155,9 @@
   <ItemGroup>
     <AndroidNativeLibrary Include="..\SafeApp.AppBindings.Android\lib\mock\armeabi-v7a\libsafe_app.so">
       <Link>lib\armeabi-v7a\libsafe_app.so</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="..\SafeApp.AppBindings.Android\lib\mock\x86_64\libsafe_app.so">
+      <Link>lib\x86_64\libsafe_app.so</Link>
     </AndroidNativeLibrary>
     <AndroidAsset Include="..\SafeApp.Tests\log.toml">
       <Link>Assets\log.toml</Link>

--- a/SafeApp.Tests.Android/SafeApp.Tests.Android.csproj
+++ b/SafeApp.Tests.Android/SafeApp.Tests.Android.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -38,7 +39,7 @@
     <AotAssemblies>false</AotAssemblies>
     <EnableLLVM>false</EnableLLVM>
     <BundleAssemblies>false</BundleAssemblies>
-    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;x86_64</AndroidSupportedAbis>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
@@ -53,7 +54,7 @@
     <AotAssemblies>false</AotAssemblies>
     <EnableLLVM>false</EnableLLVM>
     <BundleAssemblies>false</BundleAssemblies>
-    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;x86_64</AndroidSupportedAbis>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FormsViewGroup, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/SafeApp.Tests.iOS/AppDelegate.cs
+++ b/SafeApp.Tests.iOS/AppDelegate.cs
@@ -1,27 +1,4 @@
-﻿// ***********************************************************************
-// Copyright (c) 2017 Charlie Poole
-//
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-// ***********************************************************************
-
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using Foundation;
 using NUnit.Runner;
@@ -32,21 +9,11 @@ using Xamarin.Forms.Platform.iOS;
 
 namespace SafeApp.Tests.iOS
 {
-    // The UIApplicationDelegate for the application. This class is responsible for launching the
-    // User Interface of the application, as well as listening (and optionally responding) to
-    // application events from iOS.
     [Register("AppDelegate")]
     // ReSharper disable once UnusedMember.Global
     public class AppDelegate : FormsApplicationDelegate
     {
-        //
-        // This method is invoked when the application has loaded and is ready to run. In this
-        // method you should instantiate the window, load the UI into it and then make the window
-        // visible.
-        //
-        // You have 17 seconds to return from this method, or iOS will terminate your application.
-        //
-        readonly string _tcpListenHost = System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName()).AddressList.First(f => f.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork).ToString();
+        private readonly string _tcpListenHost = System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName()).AddressList.First(f => f.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork).ToString();
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
             Forms.Init();

--- a/SafeApp.Tests.iOS/AppDelegate.cs
+++ b/SafeApp.Tests.iOS/AppDelegate.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.IO;
+using System.Linq;
 using Foundation;
 using NUnit.Runner;
 using NUnit.Runner.Services;
@@ -29,55 +30,61 @@ using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
 
-namespace SafeApp.Tests.iOS {
-  // The UIApplicationDelegate for the application. This class is responsible for launching the
-  // User Interface of the application, as well as listening (and optionally responding) to
-  // application events from iOS.
-  [Register("AppDelegate")]
-  // ReSharper disable once UnusedMember.Global
-  public class AppDelegate : FormsApplicationDelegate {
-    //
-    // This method is invoked when the application has loaded and is ready to run. In this
-    // method you should instantiate the window, load the UI into it and then make the window
-    // visible.
-    //
-    // You have 17 seconds to return from this method, or iOS will terminate your application.
-    //
-    public override bool FinishedLaunching(UIApplication app, NSDictionary options) {
-      Forms.Init();
+namespace SafeApp.Tests.iOS
+{
+    // The UIApplicationDelegate for the application. This class is responsible for launching the
+    // User Interface of the application, as well as listening (and optionally responding) to
+    // application events from iOS.
+    [Register("AppDelegate")]
+    // ReSharper disable once UnusedMember.Global
+    public class AppDelegate : FormsApplicationDelegate
+    {
+        //
+        // This method is invoked when the application has loaded and is ready to run. In this
+        // method you should instantiate the window, load the UI into it and then make the window
+        // visible.
+        //
+        // You have 17 seconds to return from this method, or iOS will terminate your application.
+        //
+        readonly string _tcpListenHost = System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName()).AddressList.First(f => f.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork).ToString();
+        public override bool FinishedLaunching(UIApplication app, NSDictionary options)
+        {
+            Forms.Init();
 
-      // This will load all tests within the current project
-      var nunit = new App {
-        Options = new TestOptions {
-          // If True, the tests will run automatically when the app starts
-          // otherwise you must run them manually.
-          AutoRun = false,
+            // This will load all tests within the current project
+            var nunit = new App
+            {
+                Options = new TestOptions
+                {
+                    // If True, the tests will run automatically when the app starts
+                    // otherwise you must run them manually.
+                    AutoRun = true,
 
-          // If True, the application will terminate automatically after running the tests.
-          //TerminateAfterExecution = true,
+                    // If True, the application will terminate automatically after running the tests.
+                    //TerminateAfterExecution = true,
 
-          // Information about the tcp listener host and port.
-          // For now, send result as XML to the listening server.
-          //TcpWriterParameters = new TcpWriterInfo("192.168.0.108", 13000),
+                    // Information about the tcp listener host and port.
+                    // For now, send result as XML to the listening server.
+                    TcpWriterParameters = new TcpWriterInfo(_tcpListenHost, 10500),
 
-          // Creates a NUnit Xml result file on the host file system using PCLStorage library.
-          CreateXmlResultFile = true,
+                    // Creates a NUnit Xml result file on the host file system using PCLStorage library.
+                    CreateXmlResultFile = true,
 
-          // Choose a different path for the xml result file (ios file share / library directory)
-          ResultFilePath = Path.Combine(
-            NSFileManager.DefaultManager.GetUrls(NSSearchPathDirectory.LibraryDirectory, NSSearchPathDomain.User)[0].Path,
-            "Results.xml")
+                    // Choose a different path for the xml result file (ios file share / library directory)
+                    ResultFilePath = Path.Combine(
+                  NSFileManager.DefaultManager.GetUrls(NSSearchPathDirectory.LibraryDirectory, NSSearchPathDomain.User)[0].Path,
+                  "Results.xml")
+                }
+            };
+
+            // If you want to add tests in another assembly
+            //nunit.AddTestAssembly(typeof(MyTests).Assembly);
+
+            // Available options for testing
+
+            LoadApplication(nunit);
+
+            return base.FinishedLaunching(app, options);
         }
-      };
-
-      // If you want to add tests in another assembly
-      //nunit.AddTestAssembly(typeof(MyTests).Assembly);
-
-      // Available options for testing
-
-      LoadApplication(nunit);
-
-      return base.FinishedLaunching(app, options);
     }
-  }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - npm install gh-pages -g
 
 build_script:
-  - ps: ./build.ps1
+  - ps: ./build.ps1 --target="Run-AppVeyor-Build" --settings_skipverification=true
 
 deploy_script:
   - ps: if(-not $env:is_not_pr) { return }

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 NuGet Package : [![NuGet](https://img.shields.io/nuget/v/MaidSafe.SafeApp.svg)](https://www.nuget.org/packages/MaidSafe.SafeApp)
 
 safe_app CSharp Library. Currently supports
-- Xamarin.Android ( >=4.1.2. ABI: armeabi-v7a)
+- Xamarin.Android ( >=4.1.2. ABI: armeabi-v7a, x86_64)
 - Xamarin.iOS ( >= 1.0, ABI: ARM64, x64)
 - netstandard1.3 (for usage via portable libs)
 - netcoreapp1.0 (for use via NET Core targets. Runtime support limited to x64)


### PR DESCRIPTION
**Changes**
- Add support for Android x86_64
- Run Android tests on CI - Azure DevOps
- Run iOS tests on CI - Azure DevOps
- Run .Net Core tests for MacOs on CI - Azure DevOps
- Upload test results on CI - Azure DevOps
- Update build script to run different set of tasks for AppVeyor and Azure DevOps
- Fail build for any test fail/build fail