### PR TITLE
Refactor/NativeHandle: Add seperate null handles

### DIFF
--- a/SafeApp.Tests/MiscTest.cs
+++ b/SafeApp.Tests/MiscTest.cs
@@ -26,7 +26,7 @@ namespace SafeApp.Tests
             using (var userHandle = await session.Crypto.AppPubSignKeyAsync())
             {
                 await session.MDataPermissions.InsertAsync(permissionsHandle, userHandle, new PermissionSet { Insert = true, Delete = true });
-                await session.MData.PutAsync(mdInfo, permissionsHandle, NativeHandle.Zero);
+                await session.MData.PutAsync(mdInfo, permissionsHandle, NativeHandle.EmptyMDataEntries);
                 for (var i = 0; i < (long)accountInfo.MutationsAvailable - 1; i++)
                 {
                     var entryHandle = await session.MDataEntryActions.NewAsync();

--- a/SafeApp.Tests/MutableDataTests.cs
+++ b/SafeApp.Tests/MutableDataTests.cs
@@ -165,7 +165,7 @@ namespace SafeApp.Tests
                 using (var appSignKeyH = await session.Crypto.AppPubSignKeyAsync())
                 {
                     await session.MDataPermissions.InsertAsync(permissionsH, appSignKeyH, mDataPermissionSet);
-                    await session.MData.PutAsync(mdInfo, permissionsH, NativeHandle.Zero);
+                    await session.MData.PutAsync(mdInfo, permissionsH, NativeHandle.EmptyMDataEntries);
                 }
             }
 
@@ -213,7 +213,7 @@ namespace SafeApp.Tests
                 using (var appSignKeyH = await session.Crypto.AppPubSignKeyAsync())
                 {
                     await session.MDataPermissions.InsertAsync(permissionsH, appSignKeyH, mDataPermissionSet);
-                    await session.MData.PutAsync(mdInfo, permissionsH, NativeHandle.Zero);
+                    await session.MData.PutAsync(mdInfo, permissionsH, NativeHandle.EmptyMDataEntries);
                 }
             }
 
@@ -263,8 +263,8 @@ namespace SafeApp.Tests
                     var ownerPermission = new PermissionSet { Insert = true, ManagePermissions = true, Read = true };
                     await session.MDataPermissions.InsertAsync(permissionsH, appSignKeyH, ownerPermission);
                     var sharePermissions = new PermissionSet { Insert = true };
-                    await session.MDataPermissions.InsertAsync(permissionsH, NativeHandle.Zero, sharePermissions);
-                    await session.MData.PutAsync(mDataInfo, permissionsH, NativeHandle.Zero);
+                    await session.MDataPermissions.InsertAsync(permissionsH, NativeHandle.EmptyMDataPermissions, sharePermissions);
+                    await session.MData.PutAsync(mDataInfo, permissionsH, NativeHandle.EmptyMDataEntries);
                 }
             }
 

--- a/SafeApp.Tests/NFS.cs
+++ b/SafeApp.Tests/NFS.cs
@@ -26,7 +26,7 @@ namespace SafeApp.Tests
                   Encoding.UTF8.GetBytes("index.html").ToList(),
                   Encoding.UTF8.GetBytes("<html><body>Hello</body></html>").ToList());
                 await session.MDataPermissions.InsertAsync(permissionHandle, signPubKey, permissions);
-                await session.MData.PutAsync(mDataInfo, permissionHandle, NativeHandle.Zero);
+                await session.MData.PutAsync(mDataInfo, permissionHandle, NativeHandle.EmptyMDataEntries);
             }
 
             var fileHandle = await session.NFS.FileOpenAsync(mDataInfo, default(File), Misc.NFS.OpenMode.Overwrite);

--- a/SafeApp/NativeHandle.cs
+++ b/SafeApp/NativeHandle.cs
@@ -5,7 +5,26 @@ namespace SafeApp
 {
     public class NativeHandle : IDisposable
     {
+        /// <summary>
+        /// NativeHandle with null reference.
+        /// </summary>
+        [Obsolete("This property is obsolete.", false)]
         public static readonly NativeHandle Zero = new NativeHandle(null, 0, null);
+
+        /// <summary>
+        /// NativeHandle to insert permissions for all users.
+        /// </summary>
+        public static readonly NativeHandle AnyOne = new NativeHandle(null, 0, null);
+
+        /// <summary>
+        /// NativeHandle representing zero Mutable Data entries.
+        /// </summary>
+        public static readonly NativeHandle EmptyMDataEntries = AnyOne;
+
+        /// <summary>
+        /// NativeHandle representing zero Mutable Data Permissions.
+        /// </summary>
+        public static readonly NativeHandle EmptyMDataPermissions = AnyOne;
 
         private readonly Func<ulong, Task> _disposer;
         private readonly ulong _handle;

--- a/SafeApp/NativeHandle.cs
+++ b/SafeApp/NativeHandle.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace SafeApp
 {
     public class NativeHandle : IDisposable
     {
+        // ReSharper disable once UnusedMember.Global
+
         /// <summary>
         /// NativeHandle with null reference.
         /// </summary>
@@ -14,6 +17,7 @@ namespace SafeApp
         /// <summary>
         /// NativeHandle to insert permissions for all users.
         /// </summary>
+        [PublicAPI]
         public static readonly NativeHandle AnyOne = new NativeHandle(null, 0, null);
 
         /// <summary>


### PR DESCRIPTION
fixes: #51 

**Changes**
- Added AnyOne NativeHandle - Use to insert permissions for all users
- Added EmptyMDataEntries NativeHandle - Use to put mutable data with zero entries
- Added EmptyMDataPermissions NativeHandle - Use to put mutable data with zero permissions
- Marked Zero NativeHandle as Obsolete 