### PR TITLE
feat/CodeCoverage: Upload code coverage report to coveralls.io

### DIFF
--- a/CakeHelperScripts/DesktopTest.cake
+++ b/CakeHelperScripts/DesktopTest.cake
@@ -1,3 +1,6 @@
+#tool "nuget:?package=OpenCover"
+#tool coveralls.io
+#addin Cake.Coveralls
 
 // --------------------------------------------------------------------------------
 // Desktop Build and Test
@@ -5,7 +8,9 @@
 
 var coreTestProject = File("SafeApp.Tests.Core/SafeApp.Tests.Core.csproj");
 var coreTestBin = Directory("SafeApp.Tests.Core/bin/Release");
+var codeCoverageFilePath = "SafeApp.Tests.Core/CodeCoverResult.xml";
 var Desktop_TESTS_RESULT_PATH = "SafeApp.Tests.Core/TestResults/DesktopTestResult.xml";
+var coveralls_token = EnvironmentVariable("coveralls_access_token");
 
 Task("Build-Desktop-Project")
   .IsDependentOn("Restore-NuGet")
@@ -36,6 +41,30 @@ Task("Run-Desktop-Tests")
           Configuration = configuration,
           ArgumentCustomization = args => args.Append("--logger \"trx;LogFileName=DesktopTestResult.xml\"")
         });
+  });
+
+Task("Run-Desktop-Tests-AppVeyor")
+  .IsDependentOn("Build-Desktop-Project")
+  .Does(() => {
+    OpenCover(tool => {
+        tool.DotNetCoreTest(
+            coreTestProject,
+            new DotNetCoreTestSettings()
+            {
+              Configuration = configuration,
+              ArgumentCustomization = args => args.Append("--logger \"trx;LogFileName=DesktopTestResult.xml\"")
+            });
+        },
+        new FilePath(codeCoverageFilePath),
+        new OpenCoverSettings()
+        {
+            SkipAutoProps = true,
+            Register = "user",
+            OldStyle = true
+        }
+        .WithFilter("+[*]*")
+        .WithFilter("-[SafeApp.Tests*]*")
+        .WithFilter("-[NUnit3.*]*"));
   })
   .Finally(() =>
   {
@@ -45,3 +74,13 @@ Task("Run-Desktop-Tests")
       AppVeyor.UploadTestResults(resultsFile.Path.FullPath, AppVeyorTestResultsType.MSTest);
     }
   });
+
+Task("Upload-Coverage-Report")
+  .IsDependentOn("Run-Desktop-Tests")
+	.Does(() =>
+	{
+		CoverallsIo(codeCoverageFilePath, new CoverallsIoSettings()
+		{
+			RepoToken = coveralls_token
+		});
+	});

--- a/CakeHelperScripts/DesktopTest.cake
+++ b/CakeHelperScripts/DesktopTest.cake
@@ -76,7 +76,7 @@ Task("Run-Desktop-Tests-AppVeyor")
   });
 
 Task("Upload-Coverage-Report")
-  .WithCriteria(!EnvironmentVariable("is_not_pr"))
+  .WithCriteria(EnvironmentVariable("is_not_pr") == "true")
   .IsDependentOn("Run-Desktop-Tests")
   .Does(() => {
     CoverallsIo(codeCoverageFilePath, new CoverallsIoSettings()

--- a/CakeHelperScripts/DesktopTest.cake
+++ b/CakeHelperScripts/DesktopTest.cake
@@ -47,24 +47,24 @@ Task("Run-Desktop-Tests-AppVeyor")
   .IsDependentOn("Build-Desktop-Project")
   .Does(() => {
     OpenCover(tool => {
-        tool.DotNetCoreTest(
-            coreTestProject,
-            new DotNetCoreTestSettings()
-            {
-              Configuration = configuration,
-              ArgumentCustomization = args => args.Append("--logger \"trx;LogFileName=DesktopTestResult.xml\"")
-            });
-        },
-        new FilePath(codeCoverageFilePath),
-        new OpenCoverSettings()
-        {
-            SkipAutoProps = true,
-            Register = "user",
-            OldStyle = true
-        }
-        .WithFilter("+[*]*")
-        .WithFilter("-[SafeApp.Tests*]*")
-        .WithFilter("-[NUnit3.*]*"));
+      tool.DotNetCoreTest(
+          coreTestProject,
+          new DotNetCoreTestSettings()
+          {
+            Configuration = configuration,
+            ArgumentCustomization = args => args.Append("--logger \"trx;LogFileName=DesktopTestResult.xml\"")
+          });
+    },
+    new FilePath(codeCoverageFilePath),
+    new OpenCoverSettings()
+    {
+        SkipAutoProps = true,
+        Register = "user",
+        OldStyle = true
+    }
+    .WithFilter("+[*]*")
+    .WithFilter("-[SafeApp.Tests*]*")
+    .WithFilter("-[NUnit3.*]*"));
   })
   .Finally(() =>
   {
@@ -76,11 +76,11 @@ Task("Run-Desktop-Tests-AppVeyor")
   });
 
 Task("Upload-Coverage-Report")
+  .WithCriteria(!EnvironmentVariable("is_not_pr"))
   .IsDependentOn("Run-Desktop-Tests")
-	.Does(() =>
-	{
-		CoverallsIo(codeCoverageFilePath, new CoverallsIoSettings()
-		{
-			RepoToken = coveralls_token
-		});
-	});
+  .Does(() => {
+    CoverallsIo(codeCoverageFilePath, new CoverallsIoSettings()
+	  {
+	    RepoToken = coveralls_token
+	  });
+  });

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The documentation for the latest `safe_app_csharp` API is available at <http://d
 | Build Server | Platform                             | Status                                                                                                                                                                            |
 | ------------ | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Azure DevOps | .NET Core MacOS, Android x86_64, iOS | [![Build status](https://dev.azure.com/maidsafe/SafeApp/_apis/build/status/SafeApp-Mobile-CI)](https://dev.azure.com/maidsafe/SafeApp/_build/latest?definitionId=7)               |
-| AppVeyor     | .NET Core Windows                    | [![Build status](https://ci.appveyor.com/api/projects/status/x3m722rvosw2coao/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-app-csharp/branch/master) |  |
+| AppVeyor     | .NET Core Windows                    | [![Build status](https://ci.appveyor.com/api/projects/status/x3m722rvosw2coao/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-app-csharp/branch/master) [![Coverage Status](https://coveralls.io/repos/github/maidsafe/safe_app_csharp/badge.svg?branch=master)](https://coveralls.io/github/maidsafe/safe_app_csharp?branch=master) |  |
 
 
 ## Supported Platforms

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | CI service | Platform | Status |
 |---|---|---|
 | Azure DevOps | .NET Core MacOS, Android x86_64, iOS | [![Build status](https://dev.azure.com/maidsafe/SafeApp/_apis/build/status/SafeApp-Mobile-CI)](https://dev.azure.com/maidsafe/SafeApp/_build/latest?definitionId=7) |
-| AppVeyor | .NET Core Windows | [![Build status](https://ci.appveyor.com/api/projects/status/x3m722rvosw2coao/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-app-csharp/branch/master) |
+| AppVeyor | .NET Core Windows | [![Build status](https://ci.appveyor.com/api/projects/status/x3m722rvosw2coao/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-app-csharp/branch/master) [![Coverage Status](https://coveralls.io/repos/github/maidsafe/safe_app_csharp/badge.svg?branch=master)](https://coveralls.io/github/maidsafe/safe_app_csharp?branch=master)| |
 
 ## Table of Contents
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,6 @@ build_script:
 
 deploy_script:
   - ps: if(-not $env:is_not_pr) { return }
-  - ps: ./build.ps1 --target="Upload-Coverage-Report" --settings_skipverification=true
   - docfx ./docs/docfx.json
   - ps: gh-pages-clean
   - ps: gh-pages deploy --silent --message "doc update from CI" --dist "./docs/_site" --repo "https://$env:github_access_token@github.com/maidsafe/safe_app_csharp.git" --user "MaidSafe-QA <qa@maidsafe.net>"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ build_script:
 
 deploy_script:
   - ps: if(-not $env:is_not_pr) { return }
+  - ps: ./build.ps1 --target="Upload-Coverage-Report" --settings_skipverification=true
   - docfx ./docs/docfx.json
   - ps: gh-pages-clean
   - ps: gh-pages deploy --silent --message "doc update from CI" --dist "./docs/_site" --repo "https://$env:github_access_token@github.com/maidsafe/safe_app_csharp.git" --user "MaidSafe-QA <qa@maidsafe.net>"

--- a/build.cake
+++ b/build.cake
@@ -35,6 +35,7 @@ Task("Run-AppVeyor-Build")
   .IsDependentOn("UnZip-Libs")
   .IsDependentOn("Analyze-Project-Report")
   .IsDependentOn("Run-Desktop-Tests-AppVeyor")
+  .IsDependentOn("Upload-Coverage-Report")
   .Does(() => {
   });
 

--- a/build.cake
+++ b/build.cake
@@ -34,7 +34,7 @@ Task("Analyse-Test-Result-Files")
 Task("Run-AppVeyor-Build")
   .IsDependentOn("UnZip-Libs")
   .IsDependentOn("Analyze-Project-Report")
-  .IsDependentOn("Run-Desktop-Tests")
+  .IsDependentOn("Run-Desktop-Tests-AppVeyor")
   .Does(() => {
   });
 


### PR DESCRIPTION
Update the cake script to generate and upload code coverage to [coveralls.io](https://coveralls.io/)
- Generate code coverage report using [OpenCover](https://cakebuild.net/dsl/opencover/)
- Upload the code coverage report to coveralls.io using [Cake.Coveralls](https://cake-contrib.github.io/Cake.Coveralls)