### PR TITLE
reformat/resharper: Updated .DotSettings file & add stylecop for iOS projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ target/
 
 # Native Libs
 lib/
+libs/
 
 # Resharper
 resharper-clt-output.xml
@@ -152,6 +153,7 @@ packages/
 *.nuget.targets
 *.lock.json
 *.nuget.props
+*.nupkg
 
 ## TODO: If the tool you use requires repositories.config uncomment the next line
 #!packages/repositories.config

--- a/SafeApp.AppBindings.iOS/Properties/AssemblyInfo.cs
+++ b/SafeApp.AppBindings.iOS/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/SafeApp.AppBindings.iOS/SafeApp.AppBindings.iOS.csproj
+++ b/SafeApp.AppBindings.iOS/SafeApp.AppBindings.iOS.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" 
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -64,6 +63,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)..\CodeStyles.targets" />
   <Target Name="CheckNativeLibs" BeforeTargets="PrepareForBuild">
     <ItemGroup>
       <NativeSafeAppLibs Include="lib\**\*.a" />

--- a/SafeApp.AppBindings/AppBindings.Manual.cs
+++ b/SafeApp.AppBindings/AppBindings.Manual.cs
@@ -42,7 +42,7 @@ namespace SafeApp.AppBindings
         }
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(NoneCb))]
+        [MonoPInvokeCallback(typeof(NoneCb))]
 #endif
         private static void OnAppDisconnectCb(IntPtr userData)
         {
@@ -54,7 +54,7 @@ namespace SafeApp.AppBindings
         private static readonly NoneCb DelegateOnAppDisconnectCb = OnAppDisconnectCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultAppCb))]
+        [MonoPInvokeCallback(typeof(FfiResultAppCb))]
 #endif
         private static void OnAppCreateCb(IntPtr userData, IntPtr result, IntPtr app)
         {
@@ -82,7 +82,7 @@ namespace SafeApp.AppBindings
         }
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(UIntAuthGrantedCb))]
+        [MonoPInvokeCallback(typeof(UIntAuthGrantedCb))]
 #endif
         private static void OnDecodeIpcMsgAuthCb(IntPtr userData, uint reqId, IntPtr authGranted)
         {
@@ -93,7 +93,7 @@ namespace SafeApp.AppBindings
         private static readonly UIntAuthGrantedCb DelegateOnDecodeIpcMsgAuthCb = OnDecodeIpcMsgAuthCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(UIntByteListCb))]
+        [MonoPInvokeCallback(typeof(UIntByteListCb))]
 #endif
         private static void OnDecodeIpcMsgUnregisteredCb(IntPtr userData, uint reqId, IntPtr serialisedCfgPtr, UIntPtr serialisedCfgLen)
         {
@@ -104,7 +104,7 @@ namespace SafeApp.AppBindings
         private static readonly UIntByteListCb DelegateOnDecodeIpcMsgUnregisteredCb = OnDecodeIpcMsgUnregisteredCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(UIntCb))]
+        [MonoPInvokeCallback(typeof(UIntCb))]
 #endif
         private static void OnDecodeIpcMsgContainersCb(IntPtr userData, uint reqId)
         {
@@ -115,7 +115,7 @@ namespace SafeApp.AppBindings
         private static readonly UIntCb DelegateOnDecodeIpcMsgContainersCb = OnDecodeIpcMsgContainersCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(UIntCb))]
+        [MonoPInvokeCallback(typeof(UIntCb))]
 #endif
         private static void OnDecodeIpcMsgShareMdataCb(IntPtr userData, uint reqId)
         {
@@ -126,7 +126,7 @@ namespace SafeApp.AppBindings
         private static readonly UIntCb DelegateOnDecodeIpcMsgShareMdataCb = OnDecodeIpcMsgShareMdataCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(NoneCb))]
+        [MonoPInvokeCallback(typeof(NoneCb))]
 #endif
         private static void OnDecodeIpcMsgRevokedCb(IntPtr userData)
         {
@@ -137,7 +137,7 @@ namespace SafeApp.AppBindings
         private static readonly NoneCb DelegateOnDecodeIpcMsgRevokedCb = OnDecodeIpcMsgRevokedCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultUIntCb))]
+        [MonoPInvokeCallback(typeof(FfiResultUIntCb))]
 #endif
         private static void OnDecodeIpcMsgErrCb(IntPtr userData, IntPtr result, uint reqId)
         {

--- a/SafeApp.AppBindings/AppBindings.cs
+++ b/SafeApp.AppBindings/AppBindings.cs
@@ -16,7 +16,7 @@ namespace SafeApp.AppBindings
     internal partial class AppBindings : IAppBindings
     {
 #if __IOS__
-    private const string DllName = "__Internal";
+        private const string DllName = "__Internal";
 #else
         private const string DllName = "safe_app";
 #endif
@@ -416,14 +416,22 @@ namespace SafeApp.AppBindings
         public Task<List<byte>> EncryptAsync(IntPtr app, List<byte> data, ulong publicKeyH, ulong secretKeyH)
         {
             var (ret, userData) = BindingUtils.PrepareTask<List<byte>>();
-            EncryptNative(app, data?.ToArray(), (UIntPtr)(data?.Count ?? 0), publicKeyH, secretKeyH, userData, DelegateOnFfiResultByteListCb);
+            EncryptNative(
+                app,
+                data?.ToArray(),
+                (UIntPtr)(data?.Count ?? 0),
+                publicKeyH,
+                secretKeyH,
+                userData,
+                DelegateOnFfiResultByteListCb);
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "encrypt")]
         private static extern void EncryptNative(
             IntPtr app,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] data,
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
+            byte[] data,
             UIntPtr dataLen,
             ulong publicKeyH,
             ulong secretKeyH,
@@ -433,14 +441,22 @@ namespace SafeApp.AppBindings
         public Task<List<byte>> DecryptAsync(IntPtr app, List<byte> data, ulong publicKeyH, ulong secretKeyH)
         {
             var (ret, userData) = BindingUtils.PrepareTask<List<byte>>();
-            DecryptNative(app, data?.ToArray(), (UIntPtr)(data?.Count ?? 0), publicKeyH, secretKeyH, userData, DelegateOnFfiResultByteListCb);
+            DecryptNative(
+                app,
+                data?.ToArray(),
+                (UIntPtr)(data?.Count ?? 0),
+                publicKeyH,
+                secretKeyH,
+                userData,
+                DelegateOnFfiResultByteListCb);
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "decrypt")]
         private static extern void DecryptNative(
             IntPtr app,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] data,
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
+            byte[] data,
             UIntPtr dataLen,
             ulong publicKeyH,
             ulong secretKeyH,
@@ -467,7 +483,14 @@ namespace SafeApp.AppBindings
         public Task<List<byte>> DecryptSealedBoxAsync(IntPtr app, List<byte> data, ulong publicKeyH, ulong secretKeyH)
         {
             var (ret, userData) = BindingUtils.PrepareTask<List<byte>>();
-            DecryptSealedBoxNative(app, data?.ToArray(), (UIntPtr)(data?.Count ?? 0), publicKeyH, secretKeyH, userData, DelegateOnFfiResultByteListCb);
+            DecryptSealedBoxNative(
+                app,
+                data?.ToArray(),
+                (UIntPtr)(data?.Count ?? 0),
+                publicKeyH,
+                secretKeyH,
+                userData,
+                DelegateOnFfiResultByteListCb);
             return ret;
         }
 
@@ -1212,7 +1235,11 @@ namespace SafeApp.AppBindings
         }
 
         [DllImport(DllName, EntryPoint = "mdata_permissions_len")]
-        private static extern void MDataPermissionsLenNative(IntPtr app, ulong permissionsH, IntPtr userData, FfiResultULongFromUIntPtrCb oCb);
+        private static extern void MDataPermissionsLenNative(
+            IntPtr app,
+            ulong permissionsH,
+            IntPtr userData,
+            FfiResultULongFromUIntPtrCb oCb);
 
         public Task<PermissionSet> MDataPermissionsGetAsync(IntPtr app, ulong permissionsH, ulong userH)
         {
@@ -1411,7 +1438,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultAccountInfoCb(IntPtr userData, IntPtr result, IntPtr accountInfo);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultAccountInfoCb))]
+        [MonoPInvokeCallback(typeof(FfiResultAccountInfoCb))]
 #endif
         private static void OnFfiResultAccountInfoCb(IntPtr userData, IntPtr result, IntPtr accountInfo)
         {
@@ -1428,7 +1455,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultByteArrayAsymNonceLenCb(IntPtr userData, IntPtr result, IntPtr nonce);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultByteArrayAsymNonceLenCb))]
+        [MonoPInvokeCallback(typeof(FfiResultByteArrayAsymNonceLenCb))]
 #endif
         private static void OnFfiResultByteArrayAsymNonceLenCb(IntPtr userData, IntPtr result, IntPtr nonce)
         {
@@ -1444,7 +1471,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultByteArrayAsymPublicKeyLenCb(IntPtr userData, IntPtr result, IntPtr pubEncKey);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultByteArrayAsymPublicKeyLenCb))]
+        [MonoPInvokeCallback(typeof(FfiResultByteArrayAsymPublicKeyLenCb))]
 #endif
         private static void OnFfiResultByteArrayAsymPublicKeyLenCb(IntPtr userData, IntPtr result, IntPtr pubEncKey)
         {
@@ -1460,7 +1487,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultByteArrayAsymSecretKeyLenCb(IntPtr userData, IntPtr result, IntPtr secEncKey);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultByteArrayAsymSecretKeyLenCb))]
+        [MonoPInvokeCallback(typeof(FfiResultByteArrayAsymSecretKeyLenCb))]
 #endif
         private static void OnFfiResultByteArrayAsymSecretKeyLenCb(IntPtr userData, IntPtr result, IntPtr secEncKey)
         {
@@ -1476,7 +1503,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultByteArraySignPublicKeyLenCb(IntPtr userData, IntPtr result, IntPtr pubSignKey);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultByteArraySignPublicKeyLenCb))]
+        [MonoPInvokeCallback(typeof(FfiResultByteArraySignPublicKeyLenCb))]
 #endif
         private static void OnFfiResultByteArraySignPublicKeyLenCb(IntPtr userData, IntPtr result, IntPtr pubSignKey)
         {
@@ -1492,7 +1519,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultByteArraySignSecretKeyLenCb(IntPtr userData, IntPtr result, IntPtr pubSignKey);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultByteArraySignSecretKeyLenCb))]
+        [MonoPInvokeCallback(typeof(FfiResultByteArraySignSecretKeyLenCb))]
 #endif
         private static void OnFfiResultByteArraySignSecretKeyLenCb(IntPtr userData, IntPtr result, IntPtr pubSignKey)
         {
@@ -1508,7 +1535,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultByteArrayXorNameLenCb(IntPtr userData, IntPtr result, IntPtr name);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultByteArrayXorNameLenCb))]
+        [MonoPInvokeCallback(typeof(FfiResultByteArrayXorNameLenCb))]
 #endif
         private static void OnFfiResultByteArrayXorNameLenCb(IntPtr userData, IntPtr result, IntPtr name)
         {
@@ -1523,7 +1550,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultByteListCb(IntPtr userData, IntPtr result, IntPtr signedDataPtr, UIntPtr signedDataLen);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultByteListCb))]
+        [MonoPInvokeCallback(typeof(FfiResultByteListCb))]
 #endif
         private static void OnFfiResultByteListCb(IntPtr userData, IntPtr result, IntPtr signedDataPtr, UIntPtr signedDataLen)
         {
@@ -1543,14 +1570,9 @@ namespace SafeApp.AppBindings
             ulong version);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultByteListULongCb))]
+        [MonoPInvokeCallback(typeof(FfiResultByteListULongCb))]
 #endif
-        private static void OnFfiResultByteListULongCb(
-            IntPtr userData,
-            IntPtr result,
-            IntPtr contentPtr,
-            UIntPtr contentLen,
-            ulong version)
+        private static void OnFfiResultByteListULongCb(IntPtr userData, IntPtr result, IntPtr contentPtr, UIntPtr contentLen, ulong version)
         {
             BindingUtils.CompleteTask(
                 userData,
@@ -1563,7 +1585,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultCb(IntPtr userData, IntPtr result);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultCb))]
+        [MonoPInvokeCallback(typeof(FfiResultCb))]
 #endif
         private static void OnFfiResultCb(IntPtr userData, IntPtr result)
         {
@@ -1579,7 +1601,7 @@ namespace SafeApp.AppBindings
             UIntPtr containerPermsLen);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultContainerPermissionsListCb))]
+        [MonoPInvokeCallback(typeof(FfiResultContainerPermissionsListCb))]
 #endif
         private static void OnFfiResultContainerPermissionsListCb(
             IntPtr userData,
@@ -1599,7 +1621,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultFileCb(IntPtr userData, IntPtr result, IntPtr file);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultFileCb))]
+        [MonoPInvokeCallback(typeof(FfiResultFileCb))]
 #endif
         private static void OnFfiResultFileCb(IntPtr userData, IntPtr result, IntPtr file)
         {
@@ -1614,7 +1636,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultFileULongCb(IntPtr userData, IntPtr result, IntPtr file, ulong version);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultFileULongCb))]
+        [MonoPInvokeCallback(typeof(FfiResultFileULongCb))]
 #endif
         private static void OnFfiResultFileULongCb(IntPtr userData, IntPtr result, IntPtr file, ulong version)
         {
@@ -1629,7 +1651,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultMDataEntryListCb(IntPtr userData, IntPtr result, IntPtr entriesPtr, UIntPtr entriesLen);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultMDataEntryListCb))]
+        [MonoPInvokeCallback(typeof(FfiResultMDataEntryListCb))]
 #endif
         private static void OnFfiResultMDataEntryListCb(IntPtr userData, IntPtr result, IntPtr entriesPtr, UIntPtr entriesLen)
         {
@@ -1645,7 +1667,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultMDataInfoCb(IntPtr userData, IntPtr result, IntPtr mdataInfo);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultMDataInfoCb))]
+        [MonoPInvokeCallback(typeof(FfiResultMDataInfoCb))]
 #endif
         private static void OnFfiResultMDataInfoCb(IntPtr userData, IntPtr result, IntPtr mdataInfo)
         {
@@ -1660,7 +1682,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultMDataKeyListCb(IntPtr userData, IntPtr result, IntPtr keysPtr, UIntPtr keysLen);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultMDataKeyListCb))]
+        [MonoPInvokeCallback(typeof(FfiResultMDataKeyListCb))]
 #endif
         private static void OnFfiResultMDataKeyListCb(IntPtr userData, IntPtr result, IntPtr keysPtr, UIntPtr keysLen)
         {
@@ -1675,7 +1697,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultMDataValueListCb(IntPtr userData, IntPtr result, IntPtr valuesPtr, UIntPtr valuesLen);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultMDataValueListCb))]
+        [MonoPInvokeCallback(typeof(FfiResultMDataValueListCb))]
 #endif
         private static void OnFfiResultMDataValueListCb(IntPtr userData, IntPtr result, IntPtr valuesPtr, UIntPtr valuesLen)
         {
@@ -1691,7 +1713,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultPermissionSetCb(IntPtr userData, IntPtr result, IntPtr permSet);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultPermissionSetCb))]
+        [MonoPInvokeCallback(typeof(FfiResultPermissionSetCb))]
 #endif
         private static void OnFfiResultPermissionSetCb(IntPtr userData, IntPtr result, IntPtr permSet)
         {
@@ -1706,7 +1728,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultStringCb(IntPtr userData, IntPtr result, string logPath);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultStringCb))]
+        [MonoPInvokeCallback(typeof(FfiResultStringCb))]
 #endif
         private static void OnFfiResultStringCb(IntPtr userData, IntPtr result, string logPath)
         {
@@ -1720,7 +1742,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultUIntStringCb(IntPtr userData, IntPtr result, uint reqId, string encoded);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultUIntStringCb))]
+        [MonoPInvokeCallback(typeof(FfiResultUIntStringCb))]
 #endif
         private static void OnFfiResultUIntStringCb(IntPtr userData, IntPtr result, uint reqId, string encoded)
         {
@@ -1732,7 +1754,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultULongCb(IntPtr userData, IntPtr result, ulong handle);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultULongCb))]
+        [MonoPInvokeCallback(typeof(FfiResultULongCb))]
 #endif
         private static void OnFfiResultULongCb(IntPtr userData, IntPtr result, ulong handle)
         {
@@ -1744,7 +1766,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultULongFromUIntPtrCb(IntPtr userData, IntPtr result, UIntPtr len);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultULongFromUIntPtrCb))]
+        [MonoPInvokeCallback(typeof(FfiResultULongFromUIntPtrCb))]
 #endif
         private static void OnFfiResultULongFromUIntPtrCb(IntPtr userData, IntPtr result, UIntPtr len)
         {
@@ -1756,7 +1778,7 @@ namespace SafeApp.AppBindings
         private delegate void FfiResultULongULongCb(IntPtr userData, IntPtr result, ulong publicKeyH, ulong secretKeyH);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultULongULongCb))]
+        [MonoPInvokeCallback(typeof(FfiResultULongULongCb))]
 #endif
         private static void OnFfiResultULongULongCb(IntPtr userData, IntPtr result, ulong publicKeyH, ulong secretKeyH)
         {
@@ -1772,7 +1794,7 @@ namespace SafeApp.AppBindings
             UIntPtr userPermSetsLen);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultUserPermissionSetListCb))]
+        [MonoPInvokeCallback(typeof(FfiResultUserPermissionSetListCb))]
 #endif
         private static void OnFfiResultUserPermissionSetListCb(
             IntPtr userData,

--- a/SafeApp.MockAuthBindings.iOS/SafeApp.MockAuthBindings.iOS.csproj
+++ b/SafeApp.MockAuthBindings.iOS/SafeApp.MockAuthBindings.iOS.csproj
@@ -80,4 +80,5 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)..\CodeStyles.targets" />
 </Project>

--- a/SafeApp.MockAuthBindings/AuthBindings.Manual.cs
+++ b/SafeApp.MockAuthBindings/AuthBindings.Manual.cs
@@ -54,7 +54,7 @@ namespace SafeApp.MockAuthBindings
         }
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultAuthenticatorCb))]
+        [MonoPInvokeCallback(typeof(FfiResultAuthenticatorCb))]
 #endif
         private static void OnAuthenticatorCreateCb(IntPtr userData, IntPtr result, IntPtr app)
         {
@@ -66,7 +66,7 @@ namespace SafeApp.MockAuthBindings
         private static readonly FfiResultAuthenticatorCb DelegateOnAuthenticatorCreateCb = OnAuthenticatorCreateCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(NoneCb))]
+        [MonoPInvokeCallback(typeof(NoneCb))]
 #endif
         private static void OnAuthenticatorDisconnectCb(IntPtr userData)
         {
@@ -78,7 +78,7 @@ namespace SafeApp.MockAuthBindings
         private static readonly NoneCb DelegateOnAuthenticatorDisconnectCb = OnAuthenticatorDisconnectCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(UIntAuthReqCb))]
+        [MonoPInvokeCallback(typeof(UIntAuthReqCb))]
 #endif
         private static void OnDecodeIpcReqAuthCb(IntPtr userData, uint reqId, IntPtr authReq)
         {
@@ -89,7 +89,7 @@ namespace SafeApp.MockAuthBindings
         private static readonly UIntAuthReqCb DelegateOnDecodeIpcReqAuthCb = OnDecodeIpcReqAuthCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(UIntContainersReqCb))]
+        [MonoPInvokeCallback(typeof(UIntContainersReqCb))]
 #endif
         private static void OnDecodeIpcReqContainersCb(IntPtr userData, uint reqId, IntPtr authReq)
         {
@@ -100,7 +100,7 @@ namespace SafeApp.MockAuthBindings
         private static readonly UIntContainersReqCb DelegateOnDecodeIpcReqContainersCb = OnDecodeIpcReqContainersCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(UIntShareMDataReqMetadataResponseListCb))]
+        [MonoPInvokeCallback(typeof(UIntShareMDataReqMetadataResponseListCb))]
 #endif
         private static void OnDecodeIpcReqShareMDataCb(IntPtr userData, uint reqId, IntPtr authReq, IntPtr metadataPtr, UIntPtr metadataLen)
         {
@@ -113,7 +113,7 @@ namespace SafeApp.MockAuthBindings
         private static readonly UIntShareMDataReqMetadataResponseListCb DelegateOnDecodeIpcReqShareMDataCb = OnDecodeIpcReqShareMDataCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(UIntByteListCb))]
+        [MonoPInvokeCallback(typeof(UIntByteListCb))]
 #endif
         private static void OnDecodeIpcReqUnregisteredCb(IntPtr userData, uint reqId, IntPtr extraData, UIntPtr size)
         {
@@ -124,7 +124,7 @@ namespace SafeApp.MockAuthBindings
         private static readonly UIntByteListCb DelegateOnDecodeIpcReqUnregisteredCb = OnDecodeIpcReqUnregisteredCb;
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultIpcReqErrorCb))]
+        [MonoPInvokeCallback(typeof(FfiResultIpcReqErrorCb))]
 #endif
         private static void OnFfiResultIpcReqErrorCb(IntPtr userData, IntPtr result, string msg)
         {

--- a/SafeApp.MockAuthBindings/AuthBindings.cs
+++ b/SafeApp.MockAuthBindings/AuthBindings.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-
 using SafeApp.Utilities;
 
 namespace SafeApp.MockAuthBindings
@@ -15,7 +14,7 @@ namespace SafeApp.MockAuthBindings
     internal partial class AuthBindings : IAuthBindings
     {
 #if __IOS__
-    private const string DllName = "__Internal";
+        private const string DllName = "__Internal";
 #else
         private const string DllName = "safe_app";
 #endif
@@ -31,20 +30,20 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "create_acc")]
         private static extern void CreateAccNative(
-          [MarshalAs(UnmanagedType.LPStr)] string accountLocator,
-          [MarshalAs(UnmanagedType.LPStr)] string accountPassword,
-          [MarshalAs(UnmanagedType.LPStr)] string invitation,
-          IntPtr userData,
-          NoneCb oDisconnectNotifierCb,
-          FfiResultAuthenticatorCb oCb);
+            [MarshalAs(UnmanagedType.LPStr)] string accountLocator,
+            [MarshalAs(UnmanagedType.LPStr)] string accountPassword,
+            [MarshalAs(UnmanagedType.LPStr)] string invitation,
+            IntPtr userData,
+            NoneCb oDisconnectNotifierCb,
+            FfiResultAuthenticatorCb oCb);
 
         [DllImport(DllName, EntryPoint = "login")]
         private static extern void LoginNative(
-          [MarshalAs(UnmanagedType.LPStr)] string accountLocator,
-          [MarshalAs(UnmanagedType.LPStr)] string accountPassword,
-          IntPtr userData,
-          NoneCb oDisconnectNotifierCb,
-          FfiResultAuthenticatorCb oCb);
+            [MarshalAs(UnmanagedType.LPStr)] string accountLocator,
+            [MarshalAs(UnmanagedType.LPStr)] string accountPassword,
+            IntPtr userData,
+            NoneCb oDisconnectNotifierCb,
+            FfiResultAuthenticatorCb oCb);
 
         public Task AuthReconnectAsync(IntPtr auth)
         {
@@ -85,9 +84,9 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "auth_set_additional_search_path")]
         private static extern void AuthSetAdditionalSearchPathNative(
-          [MarshalAs(UnmanagedType.LPStr)] string newPath,
-          IntPtr userData,
-          FfiResultCb oCb);
+            [MarshalAs(UnmanagedType.LPStr)] string newPath,
+            IntPtr userData,
+            FfiResultCb oCb);
 
         public void AuthFree(IntPtr auth)
         {
@@ -106,10 +105,10 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "auth_rm_revoked_app")]
         private static extern void AuthRmRevokedAppNative(
-          IntPtr auth,
-          [MarshalAs(UnmanagedType.LPStr)] string appId,
-          IntPtr userData,
-          FfiResultCb oCb);
+            IntPtr auth,
+            [MarshalAs(UnmanagedType.LPStr)] string appId,
+            IntPtr userData,
+            FfiResultCb oCb);
 
         public Task<List<AppExchangeInfo>> AuthRevokedAppsAsync(IntPtr auth)
         {
@@ -140,29 +139,30 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "auth_apps_accessing_mutable_data")]
         private static extern void AuthAppsAccessingMutableDataNative(
-          IntPtr auth,
-          [MarshalAs(UnmanagedType.LPArray, SizeConst = (int)AppConstants.XorNameLen)] byte[] mdName,
-          ulong mdTypeTag,
-          IntPtr userData,
-          FfiResultAppAccessListCb oCb);
+            IntPtr auth,
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = (int)AppConstants.XorNameLen)]
+            byte[] mdName,
+            ulong mdTypeTag,
+            IntPtr userData,
+            FfiResultAppAccessListCb oCb);
 
         [DllImport(DllName, EntryPoint = "auth_unregistered_decode_ipc_msg")]
         private static extern void AuthUnregisteredDecodeIpcMsgNative(
-          [MarshalAs(UnmanagedType.LPStr)] string msg,
-          IntPtr userData,
-          UIntByteListCb oUnregistered,
-          FfiResultStringCb oErr);
+            [MarshalAs(UnmanagedType.LPStr)] string msg,
+            IntPtr userData,
+            UIntByteListCb oUnregistered,
+            FfiResultStringCb oErr);
 
         [DllImport(DllName, EntryPoint = "auth_decode_ipc_msg")]
         private static extern void AuthDecodeIpcMsgNative(
-          IntPtr auth,
-          [MarshalAs(UnmanagedType.LPStr)] string msg,
-          IntPtr userData,
-          UIntAuthReqCb oAuth,
-          UIntContainersReqCb oContainers,
-          UIntByteListCb oUnregistered,
-          UIntShareMDataReqMetadataResponseListCb oShareMData,
-          FfiResultStringCb oErr);
+            IntPtr auth,
+            [MarshalAs(UnmanagedType.LPStr)] string msg,
+            IntPtr userData,
+            UIntAuthReqCb oAuth,
+            UIntContainersReqCb oContainers,
+            UIntByteListCb oUnregistered,
+            UIntShareMDataReqMetadataResponseListCb oShareMData,
+            FfiResultStringCb oErr);
 
         public Task<string> EncodeShareMDataRespAsync(IntPtr auth, ref ShareMDataReq req, uint reqId, bool isGranted)
         {
@@ -175,12 +175,12 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "encode_share_mdata_resp")]
         private static extern void EncodeShareMDataRespNative(
-          IntPtr auth,
-          ref ShareMDataReqNative req,
-          uint reqId,
-          [MarshalAs(UnmanagedType.U1)] bool isGranted,
-          IntPtr userData,
-          FfiResultStringCb oCb);
+            IntPtr auth,
+            ref ShareMDataReqNative req,
+            uint reqId,
+            [MarshalAs(UnmanagedType.U1)] bool isGranted,
+            IntPtr userData,
+            FfiResultStringCb oCb);
 
         public Task<string> AuthRevokeAppAsync(IntPtr auth, string appId)
         {
@@ -191,10 +191,10 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "auth_revoke_app")]
         private static extern void AuthRevokeAppNative(
-          IntPtr auth,
-          [MarshalAs(UnmanagedType.LPStr)] string appId,
-          IntPtr userData,
-          FfiResultStringCb oCb);
+            IntPtr auth,
+            [MarshalAs(UnmanagedType.LPStr)] string appId,
+            IntPtr userData,
+            FfiResultStringCb oCb);
 
         public Task AuthFlushAppRevocationQueueAsync(IntPtr auth)
         {
@@ -215,10 +215,10 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "encode_unregistered_resp")]
         private static extern void EncodeUnregisteredRespNative(
-          uint reqId,
-          [MarshalAs(UnmanagedType.U1)] bool isGranted,
-          IntPtr userData,
-          FfiResultStringCb oCb);
+            uint reqId,
+            [MarshalAs(UnmanagedType.U1)] bool isGranted,
+            IntPtr userData,
+            FfiResultStringCb oCb);
 
         public Task<string> EncodeAuthRespAsync(IntPtr auth, ref AuthReq req, uint reqId, bool isGranted)
         {
@@ -231,12 +231,12 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "encode_auth_resp")]
         private static extern void EncodeAuthRespNative(
-          IntPtr auth,
-          ref AuthReqNative req,
-          uint reqId,
-          [MarshalAs(UnmanagedType.U1)] bool isGranted,
-          IntPtr userData,
-          FfiResultStringCb oCb);
+            IntPtr auth,
+            ref AuthReqNative req,
+            uint reqId,
+            [MarshalAs(UnmanagedType.U1)] bool isGranted,
+            IntPtr userData,
+            FfiResultStringCb oCb);
 
         public Task<string> EncodeContainersRespAsync(IntPtr auth, ref ContainersReq req, uint reqId, bool isGranted)
         {
@@ -249,12 +249,12 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "encode_containers_resp")]
         private static extern void EncodeContainersRespNative(
-          IntPtr auth,
-          ref ContainersReqNative req,
-          uint reqId,
-          [MarshalAs(UnmanagedType.U1)] bool isGranted,
-          IntPtr userData,
-          FfiResultStringCb oCb);
+            IntPtr auth,
+            ref ContainersReqNative req,
+            uint reqId,
+            [MarshalAs(UnmanagedType.U1)] bool isGranted,
+            IntPtr userData,
+            FfiResultStringCb oCb);
 
         public Task AuthInitLoggingAsync(string outputFileNameOverride)
         {
@@ -265,9 +265,9 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "auth_init_logging")]
         private static extern void AuthInitLoggingNative(
-          [MarshalAs(UnmanagedType.LPStr)] string outputFileNameOverride,
-          IntPtr userData,
-          FfiResultCb oCb);
+            [MarshalAs(UnmanagedType.LPStr)] string outputFileNameOverride,
+            IntPtr userData,
+            FfiResultCb oCb);
 
         public Task<string> AuthOutputLogPathAsync(string outputFileName)
         {
@@ -278,21 +278,21 @@ namespace SafeApp.MockAuthBindings
 
         [DllImport(DllName, EntryPoint = "auth_output_log_path")]
         private static extern void AuthOutputLogPathNative(
-          [MarshalAs(UnmanagedType.LPStr)] string outputFileName,
-          IntPtr userData,
-          FfiResultStringCb oCb);
+            [MarshalAs(UnmanagedType.LPStr)] string outputFileName,
+            IntPtr userData,
+            FfiResultStringCb oCb);
 
         private delegate void FfiResultAccountInfoCb(IntPtr userData, IntPtr result, IntPtr accountInfo);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultAccountInfoCb))]
+        [MonoPInvokeCallback(typeof(FfiResultAccountInfoCb))]
 #endif
         private static void OnFfiResultAccountInfoCb(IntPtr userData, IntPtr result, IntPtr accountInfo)
         {
             BindingUtils.CompleteTask(
-              userData,
-              Marshal.PtrToStructure<FfiResult>(result),
-              () => Marshal.PtrToStructure<AccountInfo>(accountInfo));
+                userData,
+                Marshal.PtrToStructure<FfiResult>(result),
+                () => Marshal.PtrToStructure<AccountInfo>(accountInfo));
         }
 
         private static readonly FfiResultAccountInfoCb DelegateOnFfiResultAccountInfoCb = OnFfiResultAccountInfoCb;
@@ -300,37 +300,37 @@ namespace SafeApp.MockAuthBindings
         private delegate void FfiResultAppAccessListCb(IntPtr userData, IntPtr result, IntPtr appAccessPtr, UIntPtr appAccessLen);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultAppAccessListCb))]
+        [MonoPInvokeCallback(typeof(FfiResultAppAccessListCb))]
 #endif
         private static void OnFfiResultAppAccessListCb(IntPtr userData, IntPtr result, IntPtr appAccessPtr, UIntPtr appAccessLen)
         {
             BindingUtils.CompleteTask(
-              userData,
-              Marshal.PtrToStructure<FfiResult>(result),
-              () => BindingUtils.CopyToObjectList<AppAccess>(appAccessPtr, (int)appAccessLen));
+                userData,
+                Marshal.PtrToStructure<FfiResult>(result),
+                () => BindingUtils.CopyToObjectList<AppAccess>(appAccessPtr, (int)appAccessLen));
         }
 
         private static readonly FfiResultAppAccessListCb DelegateOnFfiResultAppAccessListCb = OnFfiResultAppAccessListCb;
 
         private delegate void FfiResultAppExchangeInfoListCb(
-          IntPtr userData,
-          IntPtr result,
-          IntPtr appExchangeInfoPtr,
-          UIntPtr appExchangeInfoLen);
+            IntPtr userData,
+            IntPtr result,
+            IntPtr appExchangeInfoPtr,
+            UIntPtr appExchangeInfoLen);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultAppExchangeInfoListCb))]
+        [MonoPInvokeCallback(typeof(FfiResultAppExchangeInfoListCb))]
 #endif
         private static void OnFfiResultAppExchangeInfoListCb(
-          IntPtr userData,
-          IntPtr result,
-          IntPtr appExchangeInfoPtr,
-          UIntPtr appExchangeInfoLen)
+            IntPtr userData,
+            IntPtr result,
+            IntPtr appExchangeInfoPtr,
+            UIntPtr appExchangeInfoLen)
         {
             BindingUtils.CompleteTask(
-              userData,
-              Marshal.PtrToStructure<FfiResult>(result),
-              () => BindingUtils.CopyToObjectList<AppExchangeInfo>(appExchangeInfoPtr, (int)appExchangeInfoLen));
+                userData,
+                Marshal.PtrToStructure<FfiResult>(result),
+                () => BindingUtils.CopyToObjectList<AppExchangeInfo>(appExchangeInfoPtr, (int)appExchangeInfoLen));
         }
 
         private static readonly FfiResultAppExchangeInfoListCb DelegateOnFfiResultAppExchangeInfoListCb = OnFfiResultAppExchangeInfoListCb;
@@ -340,7 +340,7 @@ namespace SafeApp.MockAuthBindings
         private delegate void FfiResultCb(IntPtr userData, IntPtr result);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultCb))]
+        [MonoPInvokeCallback(typeof(FfiResultCb))]
 #endif
         private static void OnFfiResultCb(IntPtr userData, IntPtr result)
         {
@@ -349,18 +349,26 @@ namespace SafeApp.MockAuthBindings
 
         private static readonly FfiResultCb DelegateOnFfiResultCb = OnFfiResultCb;
 
-        private delegate void FfiResultRegisteredAppListCb(IntPtr userData, IntPtr result, IntPtr registeredAppPtr, UIntPtr registeredAppLen);
+        private delegate void FfiResultRegisteredAppListCb(
+            IntPtr userData,
+            IntPtr result,
+            IntPtr registeredAppPtr,
+            UIntPtr registeredAppLen);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultRegisteredAppListCb))]
+        [MonoPInvokeCallback(typeof(FfiResultRegisteredAppListCb))]
 #endif
-        private static void OnFfiResultRegisteredAppListCb(IntPtr userData, IntPtr result, IntPtr registeredAppPtr, UIntPtr registeredAppLen)
+        private static void OnFfiResultRegisteredAppListCb(
+            IntPtr userData,
+            IntPtr result,
+            IntPtr registeredAppPtr,
+            UIntPtr registeredAppLen)
         {
             BindingUtils.CompleteTask(
-              userData,
-              Marshal.PtrToStructure<FfiResult>(result),
-              () => BindingUtils.CopyToObjectList<RegisteredAppNative>(registeredAppPtr, (int)registeredAppLen).
-                Select(native => new RegisteredApp(native)).ToList());
+                userData,
+                Marshal.PtrToStructure<FfiResult>(result),
+                () => BindingUtils.CopyToObjectList<RegisteredAppNative>(registeredAppPtr, (int)registeredAppLen).
+                    Select(native => new RegisteredApp(native)).ToList());
         }
 
         private static readonly FfiResultRegisteredAppListCb DelegateOnFfiResultRegisteredAppListCb = OnFfiResultRegisteredAppListCb;
@@ -368,7 +376,7 @@ namespace SafeApp.MockAuthBindings
         private delegate void FfiResultStringCb(IntPtr userData, IntPtr result, string response);
 
 #if __IOS__
-    [MonoPInvokeCallback(typeof(FfiResultStringCb))]
+        [MonoPInvokeCallback(typeof(FfiResultStringCb))]
 #endif
         private static void OnFfiResultStringCb(IntPtr userData, IntPtr result, string response)
         {
@@ -395,7 +403,12 @@ namespace SafeApp.MockAuthBindings
 
         private delegate void UIntContainersReqCb(IntPtr userData, uint reqId, IntPtr req);
 
-        private delegate void UIntShareMDataReqMetadataResponseListCb(IntPtr userData, uint reqId, IntPtr req, IntPtr metadataPtr, UIntPtr metadataLen);
+        private delegate void UIntShareMDataReqMetadataResponseListCb(
+            IntPtr userData,
+            uint reqId,
+            IntPtr req,
+            IntPtr metadataPtr,
+            UIntPtr metadataLen);
     }
 }
 #endif

--- a/SafeApp.Tests/AuthTests.cs
+++ b/SafeApp.Tests/AuthTests.cs
@@ -45,35 +45,64 @@ namespace SafeApp.Tests
 
             authReq.Containers = new List<ContainerPermissions>
             {
-        new ContainerPermissions { ContName = "_public", Access = new PermissionSet { Read = true } },
-        new ContainerPermissions
-        {
-          ContName = "_videos",
-          Access = new PermissionSet { Read = true, Insert = true, Delete = false, ManagePermissions = false, Update = false }
-        },
-        new ContainerPermissions
-        {
-          ContName = "_publicNames",
-          Access = new PermissionSet { Read = true, Insert = true, Delete = false, ManagePermissions = false, Update = false }
-        },
-        new ContainerPermissions
-        {
-          ContName = "_documents",
-          Access = new PermissionSet { Read = true, Insert = true, Delete = false, ManagePermissions = false, Update = false }
-        },
-        new ContainerPermissions
-        {
-          ContName = "_music",
-          Access = new PermissionSet { Read = true, Insert = true, Delete = false, ManagePermissions = false, Update = false }
-        }
+                new ContainerPermissions { ContName = "_public", Access = new PermissionSet { Read = true } },
+                new ContainerPermissions { ContName = "_public", Access = new PermissionSet { Read = true } },
+                new ContainerPermissions
+                {
+                    ContName = "_videos",
+                    Access = new PermissionSet
+                    {
+                        Read = true,
+                        Insert = true,
+                        Delete = false,
+                        ManagePermissions = false,
+                        Update = false
+                    }
+                },
+                new ContainerPermissions
+                {
+                    ContName = "_publicNames",
+                    Access = new PermissionSet
+                    {
+                        Read = true,
+                        Insert = true,
+                        Delete = false,
+                        ManagePermissions = false,
+                        Update = false
+                    }
+                },
+                new ContainerPermissions
+                {
+                    ContName = "_documents",
+                    Access = new PermissionSet
+                    {
+                        Read = true,
+                        Insert = true,
+                        Delete = false,
+                        ManagePermissions = false,
+                        Update = false
+                    }
+                },
+                new ContainerPermissions
+                {
+                    ContName = "_music",
+                    Access = new PermissionSet
+                    {
+                        Read = true,
+                        Insert = true,
+                        Delete = false,
+                        ManagePermissions = false,
+                        Update = false
+                    }
+                }
 
-        // TODO - Enable once fixed in authenticator
-//         new ContainerPermissions()
-//        {
-//          ContName = "_pictures",
-//          Access = new PermissionSet() { Read = true, Insert = true, Delete = false, ManagePermissions = false, Update = false }
-//        }
-      };
+                // TODO - Enable once fixed in authenticator
+                //         new ContainerPermissions()
+                //        {
+                //          ContName = "_pictures",
+                //          Access = new PermissionSet() { Read = true, Insert = true, Delete = false, ManagePermissions = false, Update = false }
+                //        }
+            };
 
             using (var session = await Utils.CreateTestApp(authReq))
             {
@@ -86,8 +115,10 @@ namespace SafeApp.Tests
             var response = await Utils.AuthenticateAuthRequest(authRequest.Item2, false);
             Assert.That(async () => await Session.DecodeIpcMessageAsync(response), Throws.TypeOf<IpcMsgException>());
 
-            authReq.Containers =
-              new List<ContainerPermissions> { new ContainerPermissions { ContName = "someConatiner", Access = default(PermissionSet) } };
+            authReq.Containers = new List<ContainerPermissions>
+            {
+                new ContainerPermissions { ContName = "someConatiner", Access = default(PermissionSet) }
+            };
 
             Assert.That(async () => await Utils.CreateTestApp(authReq), Throws.TypeOf<FfiException>());
             authReq.App = new AppExchangeInfo { Id = string.Empty, Name = string.Empty, Scope = string.Empty, Vendor = string.Empty };
@@ -114,8 +145,8 @@ namespace SafeApp.Tests
                 App = authReq.App,
                 Containers = new List<ContainerPermissions>
                 {
-          new ContainerPermissions { ContName = "_public", Access = new PermissionSet { Read = true } }
-        }
+                    new ContainerPermissions { ContName = "_public", Access = new PermissionSet { Read = true } }
+                }
             };
             var (reqId, msg) = await Session.EncodeContainerRequestAsync(containerRequest);
             var responseMsg = await Utils.AuthenticateContainerRequest(locator, secret, msg, true);
@@ -132,8 +163,8 @@ namespace SafeApp.Tests
                 App = authReq.App,
                 Containers = new List<ContainerPermissions>
                 {
-          new ContainerPermissions { ContName = "_videos", Access = new PermissionSet { Read = true } }
-        }
+                    new ContainerPermissions { ContName = "_videos", Access = new PermissionSet { Read = true } }
+                }
             };
             (_, msg) = await Session.EncodeContainerRequestAsync(containerRequest);
             responseMsg = await Utils.AuthenticateContainerRequest(locator, secret, msg, false);
@@ -159,7 +190,14 @@ namespace SafeApp.Tests
             using (var userSignKeyHandle = await session.Crypto.AppPubSignKeyAsync())
             using (var permissionsHandle = await session.MDataPermissions.NewAsync())
             {
-                var permissionSet = new PermissionSet { Read = true, Insert = true, Delete = false, Update = false, ManagePermissions = false };
+                var permissionSet = new PermissionSet
+                {
+                    Read = true,
+                    Insert = true,
+                    Delete = false,
+                    Update = false,
+                    ManagePermissions = false
+                };
                 await session.MDataPermissions.InsertAsync(permissionsHandle, userSignKeyHandle, permissionSet);
                 using (var entriesHandle = await session.MDataEntries.NewAsync())
                 {
@@ -171,7 +209,10 @@ namespace SafeApp.Tests
             }
 
             session.Dispose();
-            authReq.App = new AppExchangeInfo { Id = "net.maidsafe.test.app", Name = "Test App", Scope = null, Vendor = "MaidSafe.net Ltd." };
+            authReq.App = new AppExchangeInfo
+            {
+                Id = "net.maidsafe.test.app", Name = "Test App", Scope = null, Vendor = "MaidSafe.net Ltd."
+            };
             var msg = await Session.EncodeAuthReqAsync(authReq);
             var authResponse = await Utils.AuthenticateAuthRequest(locator, secret, msg.Item2, true);
             var authGranted = await Session.DecodeIpcMessageAsync(authResponse) as AuthIpcMsg;
@@ -182,8 +223,11 @@ namespace SafeApp.Tests
                 App = authReq.App,
                 MData = new List<ShareMData>
                 {
-          new ShareMData { Name = mdInfo.Name, TypeTag = mdInfo.TypeTag, Perms = new PermissionSet { Read = true, Insert = true } }
-        }
+                    new ShareMData
+                    {
+                        Name = mdInfo.Name, TypeTag = mdInfo.TypeTag, Perms = new PermissionSet { Read = true, Insert = true }
+                    }
+                }
             };
             var ipcMsg = await Session.EncodeShareMDataRequestAsync(shareMdReq);
             var response = await Utils.AuthenticateShareMDataRequest(locator, secret, ipcMsg.Item2, true);

--- a/SafeApp.Tests/CryptoTests.cs
+++ b/SafeApp.Tests/CryptoTests.cs
@@ -24,11 +24,14 @@ namespace SafeApp.Tests
                 var decryptedBytes = await session.Crypto.DecryptAsync(cipherBytes, encKeyPairTuple.Item1, encKeyPairTuple.Item2);
                 Assert.That(decryptedBytes, Is.EqualTo(plainBytes));
                 Assert.That(
-                  async () => await session.Crypto.DecryptAsync(Utils.GetRandomData(20).ToList(), encKeyPairTuple.Item1, encKeyPairTuple.Item2),
-                  Throws.TypeOf<FfiException>());
+                    async () => await session.Crypto.DecryptAsync(
+                        Utils.GetRandomData(20).ToList(),
+                        encKeyPairTuple.Item1,
+                        encKeyPairTuple.Item2),
+                    Throws.TypeOf<FfiException>());
                 Assert.That(
-                  async () => await session.Crypto.DecryptAsync(cipherBytes, encKeyPairTuple.Item1, encKeyPairTuple.Item1),
-                  Throws.TypeOf<FfiException>());
+                    async () => await session.Crypto.DecryptAsync(cipherBytes, encKeyPairTuple.Item1, encKeyPairTuple.Item1),
+                    Throws.TypeOf<FfiException>());
             }
 
             session.Dispose();
@@ -73,11 +76,11 @@ namespace SafeApp.Tests
                 var decryptedBytes = await session.Crypto.DecryptSealedBoxAsync(cipherBytes, encKeyPairTuple.Item1, encKeyPairTuple.Item2);
                 Assert.That(decryptedBytes, Is.EqualTo(plainBytes));
                 Assert.That(
-                  async () => await session.Crypto.DecryptSealedBoxAsync(
-                    Utils.GetRandomData(10).ToList(),
-                    encKeyPairTuple.Item1,
-                    encKeyPairTuple.Item2),
-                  Throws.TypeOf<FfiException>());
+                    async () => await session.Crypto.DecryptSealedBoxAsync(
+                        Utils.GetRandomData(10).ToList(),
+                        encKeyPairTuple.Item1,
+                        encKeyPairTuple.Item2),
+                    Throws.TypeOf<FfiException>());
                 cipherBytes = await session.Crypto.EncryptSealedBoxAsync(new List<byte>(), encKeyPairTuple.Item1);
                 await session.Crypto.DecryptSealedBoxAsync(cipherBytes, encKeyPairTuple.Item1, encKeyPairTuple.Item2);
             }
@@ -98,8 +101,8 @@ namespace SafeApp.Tests
                 var verifiedData = await session.Crypto.VerifyAsync(signedData, signKeyPairTuple.Item1);
                 Assert.That(verifiedData, Is.EqualTo(plainBytes));
                 Assert.That(
-                  async () => await session.Crypto.VerifyAsync(Utils.GetRandomData(20).ToList(), signKeyPairTuple.Item1),
-                  Throws.TypeOf<FfiException>());
+                    async () => await session.Crypto.VerifyAsync(Utils.GetRandomData(20).ToList(), signKeyPairTuple.Item1),
+                    Throws.TypeOf<FfiException>());
             }
 
             session.Dispose();

--- a/SafeApp.Tests/MiscTest.cs
+++ b/SafeApp.Tests/MiscTest.cs
@@ -25,12 +25,18 @@ namespace SafeApp.Tests
             using (var permissionsHandle = await session.MDataPermissions.NewAsync())
             using (var userHandle = await session.Crypto.AppPubSignKeyAsync())
             {
-                await session.MDataPermissions.InsertAsync(permissionsHandle, userHandle, new PermissionSet { Insert = true, Delete = true });
+                await session.MDataPermissions.InsertAsync(
+                    permissionsHandle,
+                    userHandle,
+                    new PermissionSet { Insert = true, Delete = true });
                 await session.MData.PutAsync(mdInfo, permissionsHandle, NativeHandle.EmptyMDataEntries);
                 for (var i = 0; i < (long)accountInfo.MutationsAvailable - 1; i++)
                 {
                     var entryHandle = await session.MDataEntryActions.NewAsync();
-                    await session.MDataEntryActions.InsertAsync(entryHandle, Utils.GetRandomData(10).ToList(), Utils.GetRandomData(15).ToList());
+                    await session.MDataEntryActions.InsertAsync(
+                        entryHandle,
+                        Utils.GetRandomData(10).ToList(),
+                        Utils.GetRandomData(15).ToList());
                     await session.MData.MutateEntriesAsync(mdInfo, entryHandle);
                     entryHandle.Dispose();
                 }
@@ -41,8 +47,13 @@ namespace SafeApp.Tests
             Assert.That(0, Is.EqualTo(accountInfo.MutationsAvailable));
             using (var entryActionHandle = await session.MDataEntryActions.NewAsync())
             {
-                await session.MDataEntryActions.InsertAsync(entryActionHandle, Utils.GetRandomData(10).ToList(), Utils.GetRandomData(15).ToList());
-                Assert.That(async () => { await session.MData.MutateEntriesAsync(mdInfo, entryActionHandle); }, Throws.TypeOf<FfiException>());
+                await session.MDataEntryActions.InsertAsync(
+                    entryActionHandle,
+                    Utils.GetRandomData(10).ToList(),
+                    Utils.GetRandomData(15).ToList());
+                Assert.That(
+                    async () => { await session.MData.MutateEntriesAsync(mdInfo, entryActionHandle); },
+                    Throws.TypeOf<FfiException>());
             }
 
             session.Dispose();
@@ -53,7 +64,10 @@ namespace SafeApp.Tests
         {
             var authReq = new AuthReq
             {
-                App = new AppExchangeInfo { Id = Utils.GetRandomString(10), Name = Utils.GetRandomString(10), Vendor = Utils.GetRandomString(10) },
+                App = new AppExchangeInfo
+                {
+                    Id = Utils.GetRandomString(10), Name = Utils.GetRandomString(10), Vendor = Utils.GetRandomString(10)
+                },
                 AppContainer = true,
                 Containers = new List<ContainerPermissions>()
             };
@@ -80,7 +94,11 @@ namespace SafeApp.Tests
             {
                 keys = await session.MData.ListKeysAsync(mDataInfo);
                 var value = await session.MDataEntries.GetAsync(entryHandle, keys[0].Key);
-                await session.MDataEntryActions.UpdateAsync(entriesActionHandle, keys[0].Key, Utils.GetRandomData(10).ToList(), value.Item2 + 1);
+                await session.MDataEntryActions.UpdateAsync(
+                    entriesActionHandle,
+                    keys[0].Key,
+                    Utils.GetRandomData(10).ToList(),
+                    value.Item2 + 1);
                 await session.MData.MutateEntriesAsync(mDataInfo, entriesActionHandle);
             }
 
@@ -99,7 +117,10 @@ namespace SafeApp.Tests
         {
             var authReq = new AuthReq
             {
-                App = new AppExchangeInfo { Id = "net.maidsafe.scope.test", Name = "SampleTest", Scope = "Web", Vendor = "MaidSafe.net Ltd" },
+                App = new AppExchangeInfo
+                {
+                    Id = "net.maidsafe.scope.test", Name = "SampleTest", Scope = "Web", Vendor = "MaidSafe.net Ltd"
+                },
                 AppContainer = true,
                 Containers = new List<ContainerPermissions>()
             };

--- a/SafeApp.Tests/MutableDataTests.cs
+++ b/SafeApp.Tests/MutableDataTests.cs
@@ -33,10 +33,10 @@ namespace SafeApp.Tests
             Assert.NotNull(decodedResponse);
             var hostingApp = await Session.AppRegisteredAsync(authReq.App.Id, decodedResponse.AuthGranted);
             var ipcReq = await Session.EncodeShareMDataRequestAsync(
-              new ShareMDataReq
-              {
-                  App = authReq.App,
-                  MData = new List<ShareMData>
+                new ShareMDataReq
+                {
+                    App = authReq.App,
+                    MData = new List<ShareMData>
                     {
                         new ShareMData
                         {
@@ -45,15 +45,15 @@ namespace SafeApp.Tests
                             Perms = new PermissionSet { Insert = true, Read = true }
                         }
                     }
-              });
+                });
             await Utils.AuthenticateShareMDataRequest(locator, secret, ipcReq.Item2, true);
             await hostingApp.AccessContainer.RefreshAccessInfoAsync();
             using (var entryhandle = await hostingApp.MDataEntryActions.NewAsync())
             {
                 await hostingApp.MDataEntryActions.InsertAsync(
-                  entryhandle,
-                  Encoding.UTF8.GetBytes("default.html").ToList(),
-                  Encoding.UTF8.GetBytes("<html><body>Hello Default</body></html>").ToList());
+                    entryhandle,
+                    Encoding.UTF8.GetBytes("default.html").ToList(),
+                    Encoding.UTF8.GetBytes("<html><body>Hello Default</body></html>").ToList());
                 await hostingApp.MData.MutateEntriesAsync(mDataInfo, entryhandle);
             }
 
@@ -70,10 +70,12 @@ namespace SafeApp.Tests
             using (var entryHandle = await hostingApp.MDataEntryActions.NewAsync())
             {
                 await hostingApp.MDataEntryActions.InsertAsync(
-                  entryHandle,
-                  Encoding.UTF8.GetBytes("home.html").ToList(),
-                  Encoding.UTF8.GetBytes("<html><body>Hello Home!</body></html>").ToList());
-                Assert.That(async () => { await hostingApp.MData.MutateEntriesAsync(mDataInfo, entryHandle); }, Throws.TypeOf<FfiException>());
+                    entryHandle,
+                    Encoding.UTF8.GetBytes("home.html").ToList(),
+                    Encoding.UTF8.GetBytes("<html><body>Hello Home!</body></html>").ToList());
+                Assert.That(
+                    async () => { await hostingApp.MData.MutateEntriesAsync(mDataInfo, entryHandle); },
+                    Throws.TypeOf<FfiException>());
             }
 
             cmsApp.Dispose();
@@ -89,9 +91,7 @@ namespace SafeApp.Tests
             {
                 App = new AppExchangeInfo
                 {
-                    Id = "net.maidsafe.mdata.permission.delete",
-                    Name = Utils.GetRandomString(5),
-                    Vendor = "MaidSafe.net Ltd"
+                    Id = "net.maidsafe.mdata.permission.delete", Name = Utils.GetRandomString(5), Vendor = "MaidSafe.net Ltd"
                 },
                 AppContainer = true,
                 Containers = new List<ContainerPermissions>()
@@ -103,9 +103,9 @@ namespace SafeApp.Tests
             using (var appKey = await app.Crypto.AppPubSignKeyAsync())
             {
                 await app.MDataPermissions.InsertAsync(
-                  permissions,
-                  appKey,
-                  new PermissionSet { Insert = true, Delete = true, Update = true, Read = true });
+                    permissions,
+                    appKey,
+                    new PermissionSet { Insert = true, Delete = true, Update = true, Read = true });
                 for (var i = 0; i < 5; i++)
                 {
                     var key = await app.MDataInfoActions.EncryptEntryKeyAsync(mdInfo, Utils.GetRandomString(10).ToUtfBytes());
@@ -122,7 +122,11 @@ namespace SafeApp.Tests
             using (var entriesHandle = await app.MDataEntryActions.NewAsync())
             {
                 var value = await app.MData.GetValueAsync(mdInfo, keyToDelete.Key);
-                await app.MDataEntryActions.UpdateAsync(entriesHandle, keyToDelete.Key, Utils.GetRandomString(5).ToUtfBytes(), value.Item2 + 1);
+                await app.MDataEntryActions.UpdateAsync(
+                    entriesHandle,
+                    keyToDelete.Key,
+                    Utils.GetRandomString(5).ToUtfBytes(),
+                    value.Item2 + 1);
                 await app.MData.MutateEntriesAsync(mdInfo, entriesHandle);
             }
 
@@ -139,10 +143,10 @@ namespace SafeApp.Tests
             using (var entriesHandle = await app.MDataEntryActions.NewAsync())
             {
                 await app.MDataEntryActions.UpdateAsync(
-                  entriesHandle,
-                  keyToDelete.Key,
-                  Utils.GetRandomString(5).ToUtfBytes(),
-                  deletedValue.Item2 + 1);
+                    entriesHandle,
+                    keyToDelete.Key,
+                    Utils.GetRandomString(5).ToUtfBytes(),
+                    deletedValue.Item2 + 1);
                 await app.MData.MutateEntriesAsync(mdInfo, entriesHandle);
             }
 
@@ -322,7 +326,9 @@ namespace SafeApp.Tests
                     await session2.MDataEntryActions.DeleteAsync(entryAction, key.Key, encKey.Item2);
                 }
 
-                Assert.That(async () => { await session2.MData.MutateEntriesAsync(mDataInfo, entryAction); }, Throws.TypeOf<FfiException>());
+                Assert.That(
+                    async () => { await session2.MData.MutateEntriesAsync(mDataInfo, entryAction); },
+                    Throws.TypeOf<FfiException>());
             }
 
             session2.Dispose();

--- a/SafeApp.Tests/NFS.cs
+++ b/SafeApp.Tests/NFS.cs
@@ -20,11 +20,18 @@ namespace SafeApp.Tests
             using (var entryhandle = await session.MDataEntries.NewAsync())
             using (var permissionHandle = await session.MDataPermissions.NewAsync())
             {
-                var permissions = new PermissionSet { Read = true, ManagePermissions = true, Insert = true, Update = true, Delete = true };
+                var permissions = new PermissionSet
+                {
+                    Read = true,
+                    ManagePermissions = true,
+                    Insert = true,
+                    Update = true,
+                    Delete = true
+                };
                 await session.MDataEntries.InsertAsync(
-                  entryhandle,
-                  Encoding.UTF8.GetBytes("index.html").ToList(),
-                  Encoding.UTF8.GetBytes("<html><body>Hello</body></html>").ToList());
+                    entryhandle,
+                    Encoding.UTF8.GetBytes("index.html").ToList(),
+                    Encoding.UTF8.GetBytes("<html><body>Hello</body></html>").ToList());
                 await session.MDataPermissions.InsertAsync(permissionHandle, signPubKey, permissions);
                 await session.MData.PutAsync(mDataInfo, permissionHandle, NativeHandle.EmptyMDataEntries);
             }

--- a/SafeApp.Tests/Utils.cs
+++ b/SafeApp.Tests/Utils.cs
@@ -74,7 +74,10 @@ namespace SafeApp.Tests
             var secret = GetRandomString(10);
             var authReq = new AuthReq
             {
-                App = new AppExchangeInfo { Id = GetRandomString(10), Name = GetRandomString(5), Scope = null, Vendor = GetRandomString(5) },
+                App = new AppExchangeInfo
+                {
+                    Id = GetRandomString(10), Name = GetRandomString(5), Scope = null, Vendor = GetRandomString(5)
+                },
                 AppContainer = true,
                 Containers = new List<ContainerPermissions>()
             };
@@ -162,11 +165,14 @@ namespace SafeApp.Tests
                 };
                 var encMetaData = await session.MData.EncodeMetadata(metadata);
                 var permissions = new PermissionSet { Read = true, ManagePermissions = true, Insert = true };
-                await session.MDataEntries.InsertAsync(entryhandle, Encoding.UTF8.GetBytes(AppConstants.MDataMetaDataKey).ToList(), encMetaData);
                 await session.MDataEntries.InsertAsync(
-                  entryhandle,
-                  Encoding.UTF8.GetBytes("index.html").ToList(),
-                  Encoding.UTF8.GetBytes("<html><body>Hello</body></html>").ToList());
+                    entryhandle,
+                    Encoding.UTF8.GetBytes(AppConstants.MDataMetaDataKey).ToList(),
+                    encMetaData);
+                await session.MDataEntries.InsertAsync(
+                    entryhandle,
+                    Encoding.UTF8.GetBytes("index.html").ToList(),
+                    Encoding.UTF8.GetBytes("<html><body>Hello</body></html>").ToList());
                 await session.MDataPermissions.InsertAsync(permissionHandle, signPubKey, permissions);
                 await session.MData.PutAsync(mDataInfo, permissionHandle, entryhandle);
             }

--- a/SafeApp.Utilities/Helpers.cs
+++ b/SafeApp.Utilities/Helpers.cs
@@ -85,7 +85,8 @@ namespace SafeApp.Utilities
         /// <returns>list of objects.</returns>
         public static List<T> ToList<T>(this IntPtr ptr, IntPtr length)
         {
-            return Enumerable.Range(0, (int)length).Select(i => Marshal.PtrToStructure<T>(IntPtr.Add(ptr, Marshal.SizeOf<T>() * i))).ToList();
+            return Enumerable.Range(0, (int)length).Select(i => Marshal.PtrToStructure<T>(IntPtr.Add(ptr, Marshal.SizeOf<T>() * i))).
+                ToList();
         }
 
         #region Encoding Extensions

--- a/SafeApp.Utilities/IAppBindings.Manual.cs
+++ b/SafeApp.Utilities/IAppBindings.Manual.cs
@@ -8,7 +8,11 @@ namespace SafeApp.Utilities
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public partial interface IAppBindings
     {
-        void AppRegistered(string appId, ref AuthGranted authGranted, Action oDisconnectNotifierCb, Action<FfiResult, IntPtr, GCHandle> oCb);
+        void AppRegistered(
+            string appId,
+            ref AuthGranted authGranted,
+            Action oDisconnectNotifierCb,
+            Action<FfiResult, IntPtr, GCHandle> oCb);
 
         void AppUnregistered(List<byte> bootstrapConfig, Action oDisconnectNotifierCb, Action<FfiResult, IntPtr, GCHandle> oCb);
 
@@ -16,4 +20,3 @@ namespace SafeApp.Utilities
     }
 }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-

--- a/SafeApp.sln.DotSettings
+++ b/SafeApp.sln.DotSettings
@@ -51,12 +51,13 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_IFELSE/@EntryValue">Required</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_WHILE/@EntryValue">Required</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/FORCE_ATTRIBUTE_STYLE/@EntryValue">Join</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ACCESSOR_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ACCESSOR_OWNER_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	
+	
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_FOR_STMT/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">END_OF_LINE</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EMPTY_BLOCK_STYLE/@EntryValue">TOGETHER</s:String>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_BEFORE_SINGLE_LINE_COMMENT/@EntryValue">1</s:Int64>
+	
+	
+	
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FIXED_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FOR_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FOREACH_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
@@ -64,29 +65,33 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_FOREACH_STMT/@EntryValue">True</s:Boolean>
-	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_SIZE/@EntryValue">2</s:Int64>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">END_OF_LINE</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INVOCABLE_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	
+	
+	
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_EXPR_MEMBER_ARRANGEMENT/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_INITIALIZER_ARRANGEMENT/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_USER_LINEBREAKS/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/OTHER_BRACES/@EntryValue">END_OF_LINE</s:String>
+	
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSOR_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">ALWAYS</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CATCH_ON_NEW_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_COMPLEX_ACCESSOR_ATTRIBUTE_ON_SAME_LINE/@EntryValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ELSE_ON_NEW_LINE/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
+	
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FINALLY_ON_NEW_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ACCESSORHOLDER_ON_SINGLE_LINE/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_STATEMENT_ON_SAME_LINE/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_LINQ_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SIMPLE_EMBEDDED_STATEMENT_STYLE/@EntryValue">LINE_BREAK</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
-	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/TAB_WIDTH/@EntryValue">2</s:Int64>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/TYPE_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/STICK_COMMENT/@EntryValue">False</s:Boolean>
+	
+	
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/USE_INDENT_FROM_VS/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_DECLARATION_LPAR/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_DOT_IN_METHOD_CALLS/@EntryValue">True</s:Boolean>
@@ -97,6 +102,8 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_EXTENDS_LIST_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">140</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_PARAMETERS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/IndentSubtags/@EntryValue">ZeroIndent</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/IndentTagContent/@EntryValue">ZeroIndent</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/BlankLineAfterProcessingInstructions/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/LinebreaksInsideMultilineTag/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/LinebreaksInsideTagsWithTags/@EntryValue">False</s:Boolean>
@@ -229,7 +236,6 @@
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Kind Is="Member" /&gt;&#xD;
-        &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Fields"&gt;&#xD;
@@ -244,7 +250,6 @@
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Readonly /&gt;&#xD;
         &lt;Kind Is="Member" /&gt;&#xD;
-        &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Properties, Indexers"&gt;&#xD;
@@ -312,7 +317,7 @@
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="All other members"&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Name /&gt;&#xD;
+        &lt;Static /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Nested Types"&gt;&#xD;
@@ -326,6 +331,7 @@
   &lt;/TypePattern&gt;&#xD;
 &lt;/Patterns&gt;</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AllowAlias/@EntryValue">False</s:Boolean>
+	
 	<s:Boolean x:Key="/Default/CodeStyle/EncapsulateField/MakeFieldPrivate/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/EncapsulateField/UpdateExternalUsagesOnly/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderRegionName/@EntryValue">Copyright</s:String>
@@ -353,9 +359,11 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/SafeApp/MData/MDataPermissions.cs
+++ b/SafeApp/MData/MDataPermissions.cs
@@ -77,11 +77,14 @@ namespace SafeApp.MData
         {
             var userPermissions = await AppBindings.MDataListPermissionSetsAsync(_appPtr, permissionHandle);
             return userPermissions.Select(
-              userPermission =>
-              {
-                  var userHandle = new NativeHandle(_appPtr, userPermission.UserH, handle => AppBindings.SignPubKeyFreeAsync(_appPtr, handle));
-                  return (userHandle, userPermission.PermSet);
-              }).ToList();
+                userPermission =>
+                {
+                    var userHandle = new NativeHandle(
+                        _appPtr,
+                        userPermission.UserH,
+                        handle => AppBindings.SignPubKeyFreeAsync(_appPtr, handle));
+                    return (userHandle, userPermission.PermSet);
+                }).ToList();
         }
 
         /// <summary>

--- a/SafeApp/Misc/Crypto.cs
+++ b/SafeApp/Misc/Crypto.cs
@@ -97,7 +97,8 @@ namespace SafeApp.Misc
         public async Task<(NativeHandle, NativeHandle)> EncGenerateKeyPairAsync()
         {
             var (encPubKeyH, encSecKeyH) = await AppBindings.EncGenerateKeyPairAsync(_appPtr);
-            return (new NativeHandle(_appPtr, encPubKeyH, EncPubKeyFreeAsync), new NativeHandle(_appPtr, encSecKeyH, EncSecretKeyFreeAsync));
+            return (new NativeHandle(_appPtr, encPubKeyH, EncPubKeyFreeAsync),
+                new NativeHandle(_appPtr, encSecKeyH, EncSecretKeyFreeAsync));
         }
 
         /// <summary>
@@ -198,10 +199,8 @@ namespace SafeApp.Misc
         public async Task<(NativeHandle, NativeHandle)> SignGenerateKeyPairAsync()
         {
             var (publicKeyHandle, secretKeyHandle) = await AppBindings.SignGenerateKeyPairAsync(_appPtr);
-            return (new NativeHandle(_appPtr, publicKeyHandle, SignPubKeyFreeAsync), new NativeHandle(
-              _appPtr,
-              secretKeyHandle,
-              SignSecKeyFreeAsync));
+            return (new NativeHandle(_appPtr, publicKeyHandle, SignPubKeyFreeAsync),
+                new NativeHandle(_appPtr, secretKeyHandle, SignSecKeyFreeAsync));
         }
 
         private Task SignPubKeyFreeAsync(ulong pubSignKeyHandle)
@@ -210,7 +209,7 @@ namespace SafeApp.Misc
         }
 
         /// <summary>
-        ///   Get raw Sign Public Key
+        /// Get raw Sign Public Key
         /// </summary>
         /// <param name="pubSignKey">Sign Public Key NativeHandle</param>
         /// <returns>Raw Sign Public Key as List</returns>
@@ -220,7 +219,7 @@ namespace SafeApp.Misc
         }
 
         /// <summary>
-        ///   Get Sign Public Key Handle from a raw key
+        /// Get Sign Public Key Handle from a raw key
         /// </summary>
         /// <param name="rawPubSignKey">Raw Sign Public Key as List</param>
         /// <returns>Public Sign Key NativeHandle</returns>
@@ -236,7 +235,7 @@ namespace SafeApp.Misc
         }
 
         /// <summary>
-        ///   Get Raw Secret Sign Key
+        /// Get Raw Secret Sign Key
         /// </summary>
         /// <param name="secSignKey">Secret Sign Key NativeHandle</param>
         /// <returns>Raw Secret Sign Key as List</returns>
@@ -246,7 +245,7 @@ namespace SafeApp.Misc
         }
 
         /// <summary>
-        ///   Get New Sign Secret Key handle from a raw Sign Secret Key
+        /// Get New Sign Secret Key handle from a raw Sign Secret Key
         /// </summary>
         /// <param name="rawSecSignKey"></param>
         /// <returns>Secret Sign Key NativeHandle</returns>

--- a/SafeApp/Misc/NFS.cs
+++ b/SafeApp/Misc/NFS.cs
@@ -121,9 +121,9 @@ namespace SafeApp.Misc
         {
             var fileContextHandle = await AppBindings.FileOpenAsync(_appPtr, ref mDataInfo, ref file, (ulong)openMode);
             return new NativeHandle(
-              _appPtr,
-              fileContextHandle,
-              handle => { return openMode == OpenMode.Read ? AppBindings.FileCloseAsync(_appPtr, handle) : Task.Run(() => { }); });
+                _appPtr,
+                fileContextHandle,
+                handle => { return openMode == OpenMode.Read ? AppBindings.FileCloseAsync(_appPtr, handle) : Task.Run(() => { }); });
         }
 
         /// <summary>

--- a/SafeApp/NativeHandle.cs
+++ b/SafeApp/NativeHandle.cs
@@ -11,14 +11,6 @@ namespace SafeApp
     /// </summary>
     public class NativeHandle : IDisposable
     {
-        // ReSharper disable once UnusedMember.Global
-
-        /// <summary>
-        /// NativeHandle with null reference.
-        /// </summary>
-        [Obsolete("This property is obsolete.", false)]
-        public static readonly NativeHandle Zero = new NativeHandle(null, 0, null);
-
         /// <summary>
         /// NativeHandle to insert permissions for all users.
         /// </summary>
@@ -34,6 +26,14 @@ namespace SafeApp
         /// NativeHandle representing zero Mutable Data Permissions.
         /// </summary>
         public static readonly NativeHandle EmptyMDataPermissions = AnyOne;
+
+        // ReSharper disable once UnusedMember.Global
+
+        /// <summary>
+        /// NativeHandle with null reference.
+        /// </summary>
+        [Obsolete("This property is obsolete.", false)]
+        public static readonly NativeHandle Zero = new NativeHandle(null, 0, null);
 
         private readonly Func<ulong, Task> _disposer;
         private readonly ulong _handle;

--- a/SafeApp/SafeAppPtr.cs
+++ b/SafeApp/SafeAppPtr.cs
@@ -12,13 +12,8 @@ namespace SafeApp
         }
 
         public SafeAppPtr()
-          : this(IntPtr.Zero)
+            : this(IntPtr.Zero)
         {
-        }
-
-        public void Clear()
-        {
-            Value = IntPtr.Zero;
         }
 
         public static implicit operator IntPtr(SafeAppPtr obj)
@@ -29,6 +24,11 @@ namespace SafeApp
             }
 
             return obj.Value;
+        }
+
+        public void Clear()
+        {
+            Value = IntPtr.Zero;
         }
     }
 }

--- a/SafeApp/Session.cs
+++ b/SafeApp/Session.cs
@@ -77,24 +77,24 @@ namespace SafeApp
         public MDataEntries MDataEntries { get; private set; }
 
         /// <summary>
-        ///   Mutable Data Entry Actions API
+        /// Mutable Data Entry Actions API
         /// </summary>
         public MDataEntryActions MDataEntryActions { get; private set; }
 
         /// <summary>
-        ///   MDataInfo API
+        /// MDataInfo API
         /// </summary>
         public MDataInfoActions MDataInfoActions { get; private set; }
 
         /// <summary>
-        ///   Mutable Data Permissions API
+        /// Mutable Data Permissions API
         /// </summary>
         public MDataPermissions MDataPermissions { get; private set; }
 
         // ReSharper disable once InconsistentNaming
 
         /// <summary>
-        ///   Mutable Data Permissions API
+        /// Mutable Data Permissions API
         /// </summary>
         public NFS NFS { get; private set; }
 
@@ -113,29 +113,29 @@ namespace SafeApp
         public static Task<Session> AppRegisteredAsync(string appId, AuthGranted authGranted)
         {
             return Task.Run(
-              () =>
-              {
-                  var tcs = new TaskCompletionSource<Session>(TaskCreationOptions.RunContinuationsAsynchronously);
-                  var session = new Session();
-                  Action<FfiResult, IntPtr, GCHandle> acctCreatedCb = (result, ptr, disconnectedHandle) =>
-                  {
-                      if (result.ErrorCode != 0)
-                      {
-                          disconnectedHandle.Free();
+                () =>
+                {
+                    var tcs = new TaskCompletionSource<Session>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var session = new Session();
+                    Action<FfiResult, IntPtr, GCHandle> acctCreatedCb = (result, ptr, disconnectedHandle) =>
+                    {
+                        if (result.ErrorCode != 0)
+                        {
+                            disconnectedHandle.Free();
 
-                          tcs.SetException(result.ToException());
-                          return;
-                      }
+                            tcs.SetException(result.ToException());
+                            return;
+                        }
 
-                      session.Init(ptr, disconnectedHandle);
-                      tcs.SetResult(session);
-                  };
+                        session.Init(ptr, disconnectedHandle);
+                        tcs.SetResult(session);
+                    };
 
-                  Action disconnectedCb = () => { OnDisconnected(session); };
+                    Action disconnectedCb = () => { OnDisconnected(session); };
 
-                  AppBindings.AppRegistered(appId, ref authGranted, disconnectedCb, acctCreatedCb);
-                  return tcs.Task;
-              });
+                    AppBindings.AppRegistered(appId, ref authGranted, disconnectedCb, acctCreatedCb);
+                    return tcs.Task;
+                });
         }
 
         /// <summary>
@@ -147,29 +147,29 @@ namespace SafeApp
         public static Task<Session> AppUnregisteredAsync(List<byte> bootstrapConfig)
         {
             return Task.Run(
-              () =>
-              {
-                  var tcs = new TaskCompletionSource<Session>(TaskCreationOptions.RunContinuationsAsynchronously);
-                  var session = new Session();
-                  Action<FfiResult, IntPtr, GCHandle> acctCreatedCb = (result, ptr, disconnectedHandle) =>
-                  {
-                      if (result.ErrorCode != 0)
-                      {
-                          disconnectedHandle.Free();
+                () =>
+                {
+                    var tcs = new TaskCompletionSource<Session>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var session = new Session();
+                    Action<FfiResult, IntPtr, GCHandle> acctCreatedCb = (result, ptr, disconnectedHandle) =>
+                    {
+                        if (result.ErrorCode != 0)
+                        {
+                            disconnectedHandle.Free();
 
-                          tcs.SetException(result.ToException());
-                          return;
-                      }
+                            tcs.SetException(result.ToException());
+                            return;
+                        }
 
-                      session.Init(ptr, disconnectedHandle);
-                      tcs.SetResult(session);
-                  };
+                        session.Init(ptr, disconnectedHandle);
+                        tcs.SetResult(session);
+                    };
 
-                  Action disconnectedCb = () => { OnDisconnected(session); };
+                    Action disconnectedCb = () => { OnDisconnected(session); };
 
-                  AppBindings.AppUnregistered(bootstrapConfig, disconnectedCb, acctCreatedCb);
-                  return tcs.Task;
-              });
+                    AppBindings.AppUnregistered(bootstrapConfig, disconnectedCb, acctCreatedCb);
+                    return tcs.Task;
+                });
         }
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace SafeApp
         /// </summary>
         /// <param name="outputFileName">File name.</param>
         /// <returns>Log output file path along with file name.</returns>
-        public static Task<string> GetLogOutputPathAsync([Optional]string outputFileName)
+        public static Task<string> GetLogOutputPathAsync([Optional] string outputFileName)
         {
             return AppBindings.AppOutputLogPathAsync(outputFileName);
         }
@@ -353,11 +353,11 @@ namespace SafeApp
         public Task ReconnectAsync()
         {
             return Task.Run(
-              async () =>
-              {
-                  await AppBindings.AppReconnectAsync(_appPtr);
-                  IsDisconnected = false;
-              });
+                async () =>
+                {
+                    await AppBindings.AppReconnectAsync(_appPtr);
+                    IsDisconnected = false;
+                });
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes: #26 
We previously added the StyleCop and enforced the coding standards in the solution. The files are shared between the .NET Standard project and platform projects and hence the conditional statements in iOS projects never went through the StyleCop rules.
In this PR, I'm adding the StyleCop analyzer to the iOS AppBinding and MockAuthBinding projects to prevent this in future. 

The `.DotSettings` file used by the Reshaper wasn't in sync as there is no good tool available to sync the style format between StyleCop and Resharper. This PR includes a manually updated `.DotSettings` file which may need further changes in future.

This PR also includes the change in the build script to make it work with updated Appveyor .NET Core runtime, as the new test result file generated by `dotnet test` tool always has a timestamp (which was previously not enforced by test runner).