### PR TITLE
fix/SafeApp: remove IntPtr.Zero check from SafeAppPtr

### DIFF
--- a/CakeHelperScripts/iOSTest.cake
+++ b/CakeHelperScripts/iOSTest.cake
@@ -5,7 +5,7 @@
 #addin "Cake.Powershell"
 
 var IOS_SIM_NAME = EnvironmentVariable("IOS_SIM_NAME") ?? "iPhone X";
-var IOS_SIM_RUNTIME = EnvironmentVariable("IOS_SIM_RUNTIME") ?? "iOS 12.0";
+var IOS_SIM_RUNTIME = EnvironmentVariable("IOS_SIM_RUNTIME") ?? "iOS 12.1";
 var IOS_TEST_PROJ = "SafeApp.Tests.iOS/SafeApp.Tests.iOS.csproj";
 var IOS_BUNDLE_ID = "net.maidsafe.SafeApp.Tests.iOS";
 var IOS_IPA_PATH = "SafeApp.Tests.iOS/bin/iPhoneSimulator/Release/SafeApp.Tests.iOS.app";

--- a/SafeApp/SafeAppPtr.cs
+++ b/SafeApp/SafeAppPtr.cs
@@ -18,11 +18,6 @@ namespace SafeApp
 
         public static implicit operator IntPtr(SafeAppPtr obj)
         {
-            if (obj.Value == IntPtr.Zero)
-            {
-                throw new ArgumentNullException(nameof(SafeAppPtr));
-            }
-
             return obj.Value;
         }
 


### PR DESCRIPTION
When a new Session object is created, that is using following public constructor and the `_appPtr` is set to IntPtr.Zero using SafeAppPtr public constructor.

**Session.cs**
```
// Session constructor
private Session()
{
    IsDisconnected = true;
    _appPtr = new SafeAppPtr();
}
```
**SafeAppPtr.cs**
```
public IntPtr Value { get; private set; }

public SafeAppPtr(IntPtr appPtr)
{
    Value = appPtr;
}

// SafeAppPtr constructor
public SafeAppPtr() : (IntPtr.Zero)
{
}
```

So, if a Session object is out of scope/disposed/destructed the FreeApp function is called in `Session.cs` and we are checking it the `_appPtr` is already equal to `IntPtr.Zero` that means we don't have to free  the memory.

**`FreeApp()` in `Session.cs`**
```
private void FreeApp()
{
    if (_appPtr == IntPtr.Zero)
    {
        return;
    }
    AppBindings.AppFree(_appPtr);
    _appPtr.Clear();
}
```

In this code, we are converting from `_appPtr` of type `SafeAppPtr` into `IntPtr` and in `SafeAppPtr.cs` file, when the conversion/returning IntPtr value is returned we are checking if the value is, equals to `IntPtr.Zero` and throwing an exception.

**SafeAppPtr.cs**
```
public static implicit operator IntPtr(SafeAppPtr obj)
{
    if (obj.Value == IntPtr.Zero)
    {
        throw new ArgumentNullException(nameof(SafeAppPtr));
    }
    return obj.Value;
}
```
It means if we create an session object like `Session session =  new Session();` it will always throw `ArgumentNullException` on dispose. 

This PR is to remove that check.

**Other Changes:**
* Bumped iOS Simulator to use iOS version 12.2.