### PR TITLE
chore/CI: disable doc deployment and coverage report on AppVeyor

### DIFF
--- a/CakeHelperScripts/DesktopTest.cake
+++ b/CakeHelperScripts/DesktopTest.cake
@@ -100,11 +100,12 @@ Task("Run-Desktop-Tests-AppVeyor")
       throw new Exception("Test result file not found.");
     }
     
-    if(EnvironmentVariable("is_not_pr") == "true")
-    {
-      CoverallsIo(codeCoverageFilePath, new CoverallsIoSettings()
-      {
-        RepoToken = coveralls_token
-      });
-    }
+    // todo : enable after adding the new API
+    // if(EnvironmentVariable("is_not_pr") == "true")
+    // {
+    //   CoverallsIo(codeCoverageFilePath, new CoverallsIoSettings()
+    //   {
+    //     RepoToken = coveralls_token
+    //   });
+    // }
   });

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,11 @@ install:
 build_script:
   - ps: ./build.ps1 --target="Run-AppVeyor-Build" --settings_skipverification=true
 
+# todo: enable once new doc setup is in place
+deploy: off
+
 deploy_script:
   - ps: if(-not $env:is_not_pr) { return }
   - docfx ./docs/docfx.json
   - ps: gh-pages-clean
   - ps: gh-pages deploy --silent --message "doc update from CI" --dist "./docs/_site" --repo "https://$env:github_access_token@github.com/maidsafe/safe_app_csharp.git" --user "MaidSafe-QA <qa@maidsafe.net>"
-
-  


### PR DESCRIPTION
Disabling the deployment of API docs since the new API doesn't have any documentation also the code coverage reporting is disabled in this otherwise this will overwrite the coverage for the `master`/`stable` branch.