### PR TITLE
New API Integration - Keys

### DIFF
--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -84,6 +84,8 @@ namespace SafeApp.AppBindings
 
         Task<string> ValidateSkForUrlAsync(ref IntPtr app, string sk, string url);
 
+        Task<ulong> KeysTransferAsync(ref IntPtr app, string amount, string fromSk, string toUrl, ulong txId);
+
         #endregion Keys
     }
 }

--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -76,6 +76,8 @@ namespace SafeApp.AppBindings
 
         Task<(string, BlsKeyPair?)> CreateKeysAsync(ref IntPtr app, string from, string preloadAmount, string pk);
 
+        Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(ref IntPtr app, string preloadAmount);
+
         #endregion Keys
     }
 }

--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -74,7 +74,7 @@ namespace SafeApp.AppBindings
 
         Task<BlsKeyPair> GenerateKeyPairAsync(IntPtr app);
 
-        Task<(string, BlsKeyPair?)> CreateKeysAsync(IntPtr app, string from, string preloadAmount, string pk);
+        Task<(string, BlsKeyPair)> CreateKeysAsync(IntPtr app, string from, string preloadAmount, string pk);
 
         Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(IntPtr app, string preloadAmount);
 

--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -80,6 +80,8 @@ namespace SafeApp.AppBindings
 
         Task<string> KeysBalanceFromSkAsync(ref IntPtr app, string sk);
 
+        Task<string> KeysBalanceFromUrlAsync(ref IntPtr app, string url, string sk);
+
         #endregion Keys
     }
 }

--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -78,6 +78,8 @@ namespace SafeApp.AppBindings
 
         Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(ref IntPtr app, string preloadAmount);
 
+        Task<string> KeysBalanceFromSkAsync(ref IntPtr app, string sk);
+
         #endregion Keys
     }
 }

--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -69,6 +69,12 @@ namespace SafeApp.AppBindings
         Task<ISafeData> FetchAsync(IntPtr app, string uri);
 
         #endregion
+
+        #region Keys
+
+        Task<BlsKeyPair> GenerateKeyPairAsync(ref IntPtr app);
+
+        #endregion Keys
     }
 }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -72,19 +72,19 @@ namespace SafeApp.AppBindings
 
         #region Keys
 
-        Task<BlsKeyPair> GenerateKeyPairAsync(ref IntPtr app);
+        Task<BlsKeyPair> GenerateKeyPairAsync(IntPtr app);
 
-        Task<(string, BlsKeyPair?)> CreateKeysAsync(ref IntPtr app, string from, string preloadAmount, string pk);
+        Task<(string, BlsKeyPair?)> CreateKeysAsync(IntPtr app, string from, string preloadAmount, string pk);
 
-        Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(ref IntPtr app, string preloadAmount);
+        Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(IntPtr app, string preloadAmount);
 
-        Task<string> KeysBalanceFromSkAsync(ref IntPtr app, string sk);
+        Task<string> KeysBalanceFromSkAsync(IntPtr app, string sk);
 
-        Task<string> KeysBalanceFromUrlAsync(ref IntPtr app, string url, string sk);
+        Task<string> KeysBalanceFromUrlAsync(IntPtr app, string url, string sk);
 
-        Task<string> ValidateSkForUrlAsync(ref IntPtr app, string sk, string url);
+        Task<string> ValidateSkForUrlAsync(IntPtr app, string sk, string url);
 
-        Task<ulong> KeysTransferAsync(ref IntPtr app, string amount, string fromSk, string toUrl, ulong txId);
+        Task<ulong> KeysTransferAsync(IntPtr app, string amount, string fromSk, string toUrl, ulong txId);
 
         #endregion Keys
     }

--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -74,6 +74,8 @@ namespace SafeApp.AppBindings
 
         Task<BlsKeyPair> GenerateKeyPairAsync(ref IntPtr app);
 
+        Task<(string, BlsKeyPair?)> CreateKeysAsync(ref IntPtr app, string from, string preloadAmount, string pk);
+
         #endregion Keys
     }
 }

--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -82,6 +82,8 @@ namespace SafeApp.AppBindings
 
         Task<string> KeysBalanceFromUrlAsync(ref IntPtr app, string url, string sk);
 
+        Task<string> ValidateSkForUrlAsync(ref IntPtr app, string sk, string url);
+
         #endregion Keys
     }
 }

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -241,6 +241,38 @@ namespace SafeApp.AppBindings
 
         private static readonly FfiFetchFailedCb DelegateOnFfiFetchFailedCb = OnFfiFetchFailedCb;
 
-        #endregion
+        #endregion Connect
+
+        #region Keys
+
+        public Task<BlsKeyPair> GenerateKeyPairAsync(ref IntPtr app)
+        {
+            var (ret, userData) = BindingUtils.PrepareTask<BlsKeyPair>();
+            GenerateKeyPairNative(ref app, userData, DelegateOnFfiResultBlsKeyPairCb);
+            return ret;
+        }
+
+        [DllImport(DllName, EntryPoint = "generate_keypair")]
+        private static extern void GenerateKeyPairNative(
+            ref IntPtr app,
+            IntPtr userData,
+            FfiResultBlsKeyPairCb oCb);
+
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
+        private delegate void FfiResultBlsKeyPairCb(IntPtr userData, IntPtr result, IntPtr safeKey);
+
+#if __IOS__
+        [MonoPInvokeCallback(typeof(FfiResultBlsKeyPairCb))]
+#endif
+        private static void OnFfiResultBlsKeyPairCb(IntPtr userData, IntPtr result, IntPtr safeKey)
+            => BindingUtils.CompleteTask(
+                userData,
+                Marshal.PtrToStructure<FfiResult>(result),
+                () => Marshal.PtrToStructure<BlsKeyPair>(safeKey));
+
+        private static readonly FfiResultBlsKeyPairCb DelegateOnFfiResultBlsKeyPairCb = OnFfiResultBlsKeyPairCb;
+
+        #endregion Keys
     }
 }

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -395,6 +395,24 @@ namespace SafeApp.AppBindings
             FfiResultStringCb oCb);
 
         // ------------------------------------------------------------------------------------------------------------------------------------------------
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
+        public Task<string> ValidateSkForUrlAsync(ref IntPtr app, string sk, string url)
+        {
+            var (ret, userData) = BindingUtils.PrepareTask<string>();
+            ValidateSkForUrlNative(ref app, sk, url, userData, DelegateOnFfiResultStringCb);
+            return ret;
+        }
+
+        [DllImport(DllName, EntryPoint = "validate_sk_for_url")]
+        private static extern void ValidateSkForUrlNative(
+            ref IntPtr app,
+            string sk,
+            string url,
+            IntPtr userData,
+            FfiResultStringCb oCb);
+
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
 
         #endregion Keys
     }

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -273,6 +273,52 @@ namespace SafeApp.AppBindings
 
         private static readonly FfiResultBlsKeyPairCb DelegateOnFfiResultBlsKeyPairCb = OnFfiResultBlsKeyPairCb;
 
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
+        public Task<(string, BlsKeyPair?)> CreateKeysAsync(
+            ref IntPtr app,
+            string from,
+            string preloadAmount,
+            string pk)
+        {
+            var (ret, userData) = BindingUtils.PrepareTask<(string, BlsKeyPair?)>();
+            CreateKeysNative(ref app,  from, preloadAmount, pk, userData, DelegateOnFfiResultStringNullableBlsKeyPairCb);
+            return ret;
+        }
+
+        [DllImport(DllName, EntryPoint = "keys_create")]
+        private static extern void CreateKeysNative(
+            ref IntPtr app,
+            [MarshalAs(UnmanagedType.LPStr)] string from,
+            [MarshalAs(UnmanagedType.LPStr)] string preload,
+            [MarshalAs(UnmanagedType.LPStr)] string pk,
+            IntPtr userData,
+            FfiResultStringNullableBlsKeyPairCb oCb);
+
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
+        private delegate void FfiResultStringNullableBlsKeyPairCb(
+            IntPtr userData,
+            IntPtr result,
+            string xorUrl,
+            IntPtr safeKey);
+
+#if __IOS__
+        [MonoPInvokeCallback(typeof(FfiResultStringNullableBlsKeyPairCb))]
+#endif
+        private static void OnFfiResultStringNullableBlsKeyPairCb(
+            IntPtr userData,
+            IntPtr result,
+            string xorUrl,
+            IntPtr safeKey)
+            => BindingUtils.CompleteTask(
+                userData,
+                Marshal.PtrToStructure<FfiResult>(result),
+                () => (xorUrl, Marshal.PtrToStructure<BlsKeyPair?>(safeKey)));
+
+        private static readonly FfiResultStringNullableBlsKeyPairCb DelegateOnFfiResultStringNullableBlsKeyPairCb = OnFfiResultStringNullableBlsKeyPairCb;
+
         #endregion Keys
     }
 }

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -358,6 +358,26 @@ namespace SafeApp.AppBindings
                 () => (xorUrl, Marshal.PtrToStructure<BlsKeyPair>(safeKey)));
 
         private static readonly FfiResultStringBlsKeyPairCb DelegateOnFfiResultStringBlsKeyPairCb = OnFfiResultStringBlsKeyPairCb;
+
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
+        public Task<string> KeysBalanceFromSkAsync(ref IntPtr app, string sk)
+        {
+            var (ret, userData) = BindingUtils.PrepareTask<string>();
+            KeysBalanceFromSkNative(ref app, sk, userData, DelegateOnFfiResultStringCb);
+            return ret;
+        }
+
+        [DllImport(DllName, EntryPoint = "keys_balance_from_sk")]
+        private static extern void KeysBalanceFromSkNative(
+            ref IntPtr app,
+            string sk,
+            IntPtr userData,
+            FfiResultStringCb oCb);
+
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
         #endregion Keys
     }
 }

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -332,7 +332,7 @@ namespace SafeApp.AppBindings
         [DllImport(DllName, EntryPoint = "keys_create_preload_test_coins")]
         private static extern void KeysCreatePreloadTestCoinsNative(
             ref IntPtr app,
-            string preload,
+            [MarshalAs(UnmanagedType.LPStr)] string preload,
             IntPtr userData,
             FfiResultStringBlsKeyPairCb oCb);
 
@@ -372,7 +372,7 @@ namespace SafeApp.AppBindings
         [DllImport(DllName, EntryPoint = "keys_balance_from_sk")]
         private static extern void KeysBalanceFromSkNative(
             ref IntPtr app,
-            string sk,
+            [MarshalAs(UnmanagedType.LPStr)] string sk,
             IntPtr userData,
             FfiResultStringCb oCb);
 
@@ -389,8 +389,8 @@ namespace SafeApp.AppBindings
         [DllImport(DllName, EntryPoint = "keys_balance_from_url")]
         private static extern void KeysBalanceFromUrlNative(
             ref IntPtr app,
-            string url,
-            string sk,
+            [MarshalAs(UnmanagedType.LPStr)] string url,
+            [MarshalAs(UnmanagedType.LPStr)] string sk,
             IntPtr userData,
             FfiResultStringCb oCb);
 
@@ -407,8 +407,8 @@ namespace SafeApp.AppBindings
         [DllImport(DllName, EntryPoint = "validate_sk_for_url")]
         private static extern void ValidateSkForUrlNative(
             ref IntPtr app,
-            string sk,
-            string url,
+            [MarshalAs(UnmanagedType.LPStr)] string sk,
+            [MarshalAs(UnmanagedType.LPStr)] string url,
             IntPtr userData,
             FfiResultStringCb oCb);
 
@@ -425,9 +425,9 @@ namespace SafeApp.AppBindings
         [DllImport(DllName, EntryPoint = "keys_transfer")]
         private static extern void KeysTransferNative(
             ref IntPtr app,
-            string amount,
-            string from,
-            string to,
+            [MarshalAs(UnmanagedType.LPStr)] string amount,
+            [MarshalAs(UnmanagedType.LPStr)] string from,
+            [MarshalAs(UnmanagedType.LPStr)] string to,
             ulong id,
             IntPtr userData,
             FfiResultULongCb oCb);

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -245,16 +245,16 @@ namespace SafeApp.AppBindings
 
         #region Keys
 
-        public Task<BlsKeyPair> GenerateKeyPairAsync(ref IntPtr app)
+        public Task<BlsKeyPair> GenerateKeyPairAsync(IntPtr app)
         {
             var (ret, userData) = BindingUtils.PrepareTask<BlsKeyPair>();
-            GenerateKeyPairNative(ref app, userData, DelegateOnFfiResultBlsKeyPairCb);
+            GenerateKeyPairNative(app, userData, DelegateOnFfiResultBlsKeyPairCb);
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "generate_keypair")]
         private static extern void GenerateKeyPairNative(
-            ref IntPtr app,
+            IntPtr app,
             IntPtr userData,
             FfiResultBlsKeyPairCb oCb);
 
@@ -272,19 +272,19 @@ namespace SafeApp.AppBindings
         private static readonly FfiResultBlsKeyPairCb DelegateOnFfiResultBlsKeyPairCb = OnFfiResultBlsKeyPairCb;
 
         public Task<(string, BlsKeyPair?)> CreateKeysAsync(
-            ref IntPtr app,
+            IntPtr app,
             string from,
             string preloadAmount,
             string pk)
         {
             var (ret, userData) = BindingUtils.PrepareTask<(string, BlsKeyPair?)>();
-            CreateKeysNative(ref app,  from, preloadAmount, pk, userData, DelegateOnFfiResultStringNullableBlsKeyPairCb);
+            CreateKeysNative(app,  from, preloadAmount, pk, userData, DelegateOnFfiResultStringNullableBlsKeyPairCb);
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "keys_create")]
         private static extern void CreateKeysNative(
-            ref IntPtr app,
+            IntPtr app,
             [MarshalAs(UnmanagedType.LPStr)] string from,
             [MarshalAs(UnmanagedType.LPStr)] string preload,
             [MarshalAs(UnmanagedType.LPStr)] string pk,
@@ -312,16 +312,16 @@ namespace SafeApp.AppBindings
 
         private static readonly FfiResultStringNullableBlsKeyPairCb DelegateOnFfiResultStringNullableBlsKeyPairCb = OnFfiResultStringNullableBlsKeyPairCb;
 
-        public Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(ref IntPtr app, string preloadAmount)
+        public Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(IntPtr app, string preloadAmount)
         {
             var (ret, userData) = BindingUtils.PrepareTask<(string, BlsKeyPair)>();
-            KeysCreatePreloadTestCoinsNative(ref app, preloadAmount, userData, DelegateOnFfiResultStringBlsKeyPairCb);
+            KeysCreatePreloadTestCoinsNative(app, preloadAmount, userData, DelegateOnFfiResultStringBlsKeyPairCb);
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "keys_create_preload_test_coins")]
         private static extern void KeysCreatePreloadTestCoinsNative(
-            ref IntPtr app,
+            IntPtr app,
             [MarshalAs(UnmanagedType.LPStr)] string preload,
             IntPtr userData,
             FfiResultStringBlsKeyPairCb oCb);
@@ -347,60 +347,60 @@ namespace SafeApp.AppBindings
 
         private static readonly FfiResultStringBlsKeyPairCb DelegateOnFfiResultStringBlsKeyPairCb = OnFfiResultStringBlsKeyPairCb;
 
-        public Task<string> KeysBalanceFromSkAsync(ref IntPtr app, string sk)
+        public Task<string> KeysBalanceFromSkAsync(IntPtr app, string sk)
         {
             var (ret, userData) = BindingUtils.PrepareTask<string>();
-            KeysBalanceFromSkNative(ref app, sk, userData, DelegateOnFfiResultStringCb);
+            KeysBalanceFromSkNative(app, sk, userData, DelegateOnFfiResultStringCb);
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "keys_balance_from_sk")]
         private static extern void KeysBalanceFromSkNative(
-            ref IntPtr app,
+            IntPtr app,
             [MarshalAs(UnmanagedType.LPStr)] string sk,
             IntPtr userData,
             FfiResultStringCb oCb);
 
-        public Task<string> KeysBalanceFromUrlAsync(ref IntPtr app, string url, string sk)
+        public Task<string> KeysBalanceFromUrlAsync(IntPtr app, string url, string sk)
         {
             var (ret, userData) = BindingUtils.PrepareTask<string>();
-            KeysBalanceFromUrlNative(ref app, url, sk, userData, DelegateOnFfiResultStringCb);
+            KeysBalanceFromUrlNative(app, url, sk, userData, DelegateOnFfiResultStringCb);
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "keys_balance_from_url")]
         private static extern void KeysBalanceFromUrlNative(
-            ref IntPtr app,
+            IntPtr app,
             [MarshalAs(UnmanagedType.LPStr)] string url,
             [MarshalAs(UnmanagedType.LPStr)] string sk,
             IntPtr userData,
             FfiResultStringCb oCb);
 
-        public Task<string> ValidateSkForUrlAsync(ref IntPtr app, string sk, string url)
+        public Task<string> ValidateSkForUrlAsync(IntPtr app, string sk, string url)
         {
             var (ret, userData) = BindingUtils.PrepareTask<string>();
-            ValidateSkForUrlNative(ref app, sk, url, userData, DelegateOnFfiResultStringCb);
+            ValidateSkForUrlNative(app, sk, url, userData, DelegateOnFfiResultStringCb);
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "validate_sk_for_url")]
         private static extern void ValidateSkForUrlNative(
-            ref IntPtr app,
+            IntPtr app,
             [MarshalAs(UnmanagedType.LPStr)] string sk,
             [MarshalAs(UnmanagedType.LPStr)] string url,
             IntPtr userData,
             FfiResultStringCb oCb);
 
-        public Task<ulong> KeysTransferAsync(ref IntPtr app, string amount, string fromSk, string toUrl, ulong txId)
+        public Task<ulong> KeysTransferAsync(IntPtr app, string amount, string fromSk, string toUrl, ulong txId)
         {
             var (ret, userData) = BindingUtils.PrepareTask<ulong>();
-            KeysTransferNative(ref app, amount, fromSk, toUrl, txId, userData, DelegateOnFfiResultULongCb);
+            KeysTransferNative(app, amount, fromSk, toUrl, txId, userData, DelegateOnFfiResultULongCb);
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "keys_transfer")]
         private static extern void KeysTransferNative(
-            ref IntPtr app,
+            IntPtr app,
             [MarshalAs(UnmanagedType.LPStr)] string amount,
             [MarshalAs(UnmanagedType.LPStr)] string from,
             [MarshalAs(UnmanagedType.LPStr)] string to,

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -413,6 +413,38 @@ namespace SafeApp.AppBindings
             FfiResultStringCb oCb);
 
         // ------------------------------------------------------------------------------------------------------------------------------------------------
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
+        public Task<ulong> KeysTransferAsync(ref IntPtr app, string amount, string fromSk, string toUrl, ulong txId)
+        {
+            var (ret, userData) = BindingUtils.PrepareTask<ulong>();
+            KeysTransferNative(ref app, amount, fromSk, toUrl, txId, userData, DelegateOnFfiResultULongCb);
+            return ret;
+        }
+
+        [DllImport(DllName, EntryPoint = "keys_transfer")]
+        private static extern void KeysTransferNative(
+            ref IntPtr app,
+            string amount,
+            string from,
+            string to,
+            ulong id,
+            IntPtr userData,
+            FfiResultULongCb oCb);
+
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
+        private delegate void FfiResultULongCb(IntPtr userData, IntPtr result, ulong handle);
+
+#if __IOS__
+        [MonoPInvokeCallback(typeof(FfiResultULongCb))]
+#endif
+        private static void OnFfiResultULongCb(IntPtr userData, IntPtr result, ulong handle)
+        {
+            BindingUtils.CompleteTask(userData, Marshal.PtrToStructure<FfiResult>(result), () => handle);
+        }
+
+        private static readonly FfiResultULongCb DelegateOnFfiResultULongCb = OnFfiResultULongCb;
 
         #endregion Keys
     }

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -377,6 +377,24 @@ namespace SafeApp.AppBindings
             FfiResultStringCb oCb);
 
         // ------------------------------------------------------------------------------------------------------------------------------------------------
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
+        public Task<string> KeysBalanceFromUrlAsync(ref IntPtr app, string url, string sk)
+        {
+            var (ret, userData) = BindingUtils.PrepareTask<string>();
+            KeysBalanceFromUrlNative(ref app, url, sk, userData, DelegateOnFfiResultStringCb);
+            return ret;
+        }
+
+        [DllImport(DllName, EntryPoint = "keys_balance_from_url")]
+        private static extern void KeysBalanceFromUrlNative(
+            ref IntPtr app,
+            string url,
+            string sk,
+            IntPtr userData,
+            FfiResultStringCb oCb);
+
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
 
         #endregion Keys
     }

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -258,8 +258,6 @@ namespace SafeApp.AppBindings
             IntPtr userData,
             FfiResultBlsKeyPairCb oCb);
 
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
-
         private delegate void FfiResultBlsKeyPairCb(IntPtr userData, IntPtr result, IntPtr safeKey);
 
 #if __IOS__
@@ -272,9 +270,6 @@ namespace SafeApp.AppBindings
                 () => Marshal.PtrToStructure<BlsKeyPair>(safeKey));
 
         private static readonly FfiResultBlsKeyPairCb DelegateOnFfiResultBlsKeyPairCb = OnFfiResultBlsKeyPairCb;
-
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
 
         public Task<(string, BlsKeyPair?)> CreateKeysAsync(
             ref IntPtr app,
@@ -295,8 +290,6 @@ namespace SafeApp.AppBindings
             [MarshalAs(UnmanagedType.LPStr)] string pk,
             IntPtr userData,
             FfiResultStringNullableBlsKeyPairCb oCb);
-
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
 
         private delegate void FfiResultStringNullableBlsKeyPairCb(
             IntPtr userData,
@@ -319,9 +312,6 @@ namespace SafeApp.AppBindings
 
         private static readonly FfiResultStringNullableBlsKeyPairCb DelegateOnFfiResultStringNullableBlsKeyPairCb = OnFfiResultStringNullableBlsKeyPairCb;
 
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
-
         public Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(ref IntPtr app, string preloadAmount)
         {
             var (ret, userData) = BindingUtils.PrepareTask<(string, BlsKeyPair)>();
@@ -335,8 +325,6 @@ namespace SafeApp.AppBindings
             [MarshalAs(UnmanagedType.LPStr)] string preload,
             IntPtr userData,
             FfiResultStringBlsKeyPairCb oCb);
-
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
 
         private delegate void FfiResultStringBlsKeyPairCb(
             IntPtr userData,
@@ -359,9 +347,6 @@ namespace SafeApp.AppBindings
 
         private static readonly FfiResultStringBlsKeyPairCb DelegateOnFfiResultStringBlsKeyPairCb = OnFfiResultStringBlsKeyPairCb;
 
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
-
         public Task<string> KeysBalanceFromSkAsync(ref IntPtr app, string sk)
         {
             var (ret, userData) = BindingUtils.PrepareTask<string>();
@@ -375,9 +360,6 @@ namespace SafeApp.AppBindings
             [MarshalAs(UnmanagedType.LPStr)] string sk,
             IntPtr userData,
             FfiResultStringCb oCb);
-
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
 
         public Task<string> KeysBalanceFromUrlAsync(ref IntPtr app, string url, string sk)
         {
@@ -394,9 +376,6 @@ namespace SafeApp.AppBindings
             IntPtr userData,
             FfiResultStringCb oCb);
 
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
-
         public Task<string> ValidateSkForUrlAsync(ref IntPtr app, string sk, string url)
         {
             var (ret, userData) = BindingUtils.PrepareTask<string>();
@@ -411,9 +390,6 @@ namespace SafeApp.AppBindings
             [MarshalAs(UnmanagedType.LPStr)] string url,
             IntPtr userData,
             FfiResultStringCb oCb);
-
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
 
         public Task<ulong> KeysTransferAsync(ref IntPtr app, string amount, string fromSk, string toUrl, ulong txId)
         {
@@ -431,8 +407,6 @@ namespace SafeApp.AppBindings
             ulong id,
             IntPtr userData,
             FfiResultULongCb oCb);
-
-        // ------------------------------------------------------------------------------------------------------------------------------------------------
 
         private delegate void FfiResultULongCb(IntPtr userData, IntPtr result, ulong handle);
 

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -271,14 +271,14 @@ namespace SafeApp.AppBindings
 
         private static readonly FfiResultBlsKeyPairCb DelegateOnFfiResultBlsKeyPairCb = OnFfiResultBlsKeyPairCb;
 
-        public Task<(string, BlsKeyPair?)> CreateKeysAsync(
+        public Task<(string, BlsKeyPair)> CreateKeysAsync(
             IntPtr app,
             string from,
             string preloadAmount,
             string pk)
         {
-            var (ret, userData) = BindingUtils.PrepareTask<(string, BlsKeyPair?)>();
-            CreateKeysNative(app,  from, preloadAmount, pk, userData, DelegateOnFfiResultStringNullableBlsKeyPairCb);
+            var (ret, userData) = BindingUtils.PrepareTask<(string, BlsKeyPair)>();
+            CreateKeysNative(app,  from, preloadAmount, pk, userData, DelegateOnFfiResultStringBlsKeyPairCb);
             return ret;
         }
 
@@ -289,28 +289,7 @@ namespace SafeApp.AppBindings
             [MarshalAs(UnmanagedType.LPStr)] string preload,
             [MarshalAs(UnmanagedType.LPStr)] string pk,
             IntPtr userData,
-            FfiResultStringNullableBlsKeyPairCb oCb);
-
-        private delegate void FfiResultStringNullableBlsKeyPairCb(
-            IntPtr userData,
-            IntPtr result,
-            string xorUrl,
-            IntPtr safeKey);
-
-#if __IOS__
-        [MonoPInvokeCallback(typeof(FfiResultStringNullableBlsKeyPairCb))]
-#endif
-        private static void OnFfiResultStringNullableBlsKeyPairCb(
-            IntPtr userData,
-            IntPtr result,
-            string xorUrl,
-            IntPtr safeKey)
-            => BindingUtils.CompleteTask(
-                userData,
-                Marshal.PtrToStructure<FfiResult>(result),
-                () => (xorUrl, Marshal.PtrToStructure<BlsKeyPair?>(safeKey)));
-
-        private static readonly FfiResultStringNullableBlsKeyPairCb DelegateOnFfiResultStringNullableBlsKeyPairCb = OnFfiResultStringNullableBlsKeyPairCb;
+            FfiResultStringBlsKeyPairCb oCb);
 
         public Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(IntPtr app, string preloadAmount)
         {

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -319,6 +319,45 @@ namespace SafeApp.AppBindings
 
         private static readonly FfiResultStringNullableBlsKeyPairCb DelegateOnFfiResultStringNullableBlsKeyPairCb = OnFfiResultStringNullableBlsKeyPairCb;
 
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
+        public Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(ref IntPtr app, string preloadAmount)
+        {
+            var (ret, userData) = BindingUtils.PrepareTask<(string, BlsKeyPair)>();
+            KeysCreatePreloadTestCoinsNative(ref app, preloadAmount, userData, DelegateOnFfiResultStringBlsKeyPairCb);
+            return ret;
+        }
+
+        [DllImport(DllName, EntryPoint = "keys_create_preload_test_coins")]
+        private static extern void KeysCreatePreloadTestCoinsNative(
+            ref IntPtr app,
+            string preload,
+            IntPtr userData,
+            FfiResultStringBlsKeyPairCb oCb);
+
+        // ------------------------------------------------------------------------------------------------------------------------------------------------
+
+        private delegate void FfiResultStringBlsKeyPairCb(
+            IntPtr userData,
+            IntPtr result,
+            string xorUrl,
+            IntPtr safeKey);
+
+#if __IOS__
+        [MonoPInvokeCallback(typeof(FfiResultStringBlsKeyPairCb))]
+#endif
+        private static void OnFfiResultStringBlsKeyPairCb(
+            IntPtr userData,
+            IntPtr result,
+            string xorUrl,
+            IntPtr safeKey)
+            => BindingUtils.CompleteTask(
+                userData,
+                Marshal.PtrToStructure<FfiResult>(result),
+                () => (xorUrl, Marshal.PtrToStructure<BlsKeyPair>(safeKey)));
+
+        private static readonly FfiResultStringBlsKeyPairCb DelegateOnFfiResultStringBlsKeyPairCb = OnFfiResultStringBlsKeyPairCb;
         #endregion Keys
     }
 }

--- a/SafeApp.AppBindings/SafeApp.AppBindings.csproj
+++ b/SafeApp.AppBindings/SafeApp.AppBindings.csproj
@@ -32,6 +32,12 @@
     <ProjectReference Include="..\SafeApp.Core\SafeApp.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="NativeLibs\Desktop\mock\safe_api_ffi.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <Target Name="CheckNativeLibs" BeforeTargets="DispatchToInnerBuilds">
     <PropertyGroup>
       <AndroidLibsExists Condition=" '@(AndroidNativeLibs-&gt;Count())' == '0' ">true</AndroidLibsExists>

--- a/SafeApp.AppBindings/SafeApp.AppBindings.csproj
+++ b/SafeApp.AppBindings/SafeApp.AppBindings.csproj
@@ -32,12 +32,6 @@
     <ProjectReference Include="..\SafeApp.Core\SafeApp.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="NativeLibs\Desktop\mock\safe_api_ffi.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
   <Target Name="CheckNativeLibs" BeforeTargets="DispatchToInnerBuilds">
     <PropertyGroup>
       <AndroidLibsExists Condition=" '@(AndroidNativeLibs-&gt;Count())' == '0' ">true</AndroidLibsExists>

--- a/SafeApp.Core/AppTypes.Manual.cs
+++ b/SafeApp.Core/AppTypes.Manual.cs
@@ -4,6 +4,23 @@ using JetBrains.Annotations;
 namespace SafeApp.Core
 {
 #pragma warning disable SA1401 // Fields should be private
+
+    /// <summary>
+    /// Public and secret BLS key.
+    /// </summary>
+    public struct BlsKeyPair
+    {
+        /// <summary>
+        /// Public key.
+        /// </summary>
+        public string PK { get; set; }
+
+        /// <summary>
+        /// Secret key.
+        /// </summary>
+        public string SK { get; set; }
+    }
+
     /// <summary>
     /// Base IPC response message.
     /// </summary>

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -54,5 +54,8 @@ namespace SafeApp.API
 
         public Task<string> ValidateSkForUrlAsync(string sk, string url)
             => AppBindings.ValidateSkForUrlAsync(ref _appPtr, sk, url);
+
+        public Task<ulong> KeysTransferAsync(string amount, string fromSk, string toUrl, ulong txId)
+            => AppBindings.KeysTransferAsync(ref _appPtr, amount, fromSk, toUrl, txId);
     }
 }

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -36,25 +36,57 @@ namespace SafeApp.API
         /// <param name="from">Secret key of source funds.</param>
         /// <param name="preloadAmount">Optional amount of funds to send.</param>
         /// <param name="pk">Public key of recipient if provided.</param>
-        /// <returns>Xor url of the balance, and a new key pair if no public key was provided.</returns>
+        /// <returns>XOR url of the balance, and a new key pair if no public key was provided.</returns>
         public Task<(string, BlsKeyPair?)> CreateKeysAsync(
             string from,
             string preloadAmount,
             string pk)
             => AppBindings.CreateKeysAsync(ref _appPtr, from, preloadAmount, pk);
 
+        /// <summary>
+        /// Create a SafeKey on the network, allocates testcoins onto it, and return the SafeKey's XOR-URL.
+        /// </summary>
+        /// <param name="preloadAmount">Amount of funds to send.</param>
+        /// <returns>XOR url of the balance, and a new key pair.</returns>
         public Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(string preloadAmount)
             => AppBindings.KeysCreatePreloadTestCoinsAsync(ref _appPtr, preloadAmount);
 
+        /// <summary>
+        /// Check SafeKey's balance from the network from a given SecretKey string.
+        /// </summary>
+        /// <param name="sk">The secret key.</param>
+        /// <returns>The balance.</returns>
         public Task<string> KeysBalanceFromSkAsync(string sk)
             => AppBindings.KeysBalanceFromSkAsync(ref _appPtr, sk);
 
+        /// <summary>
+        /// Check SafeKey's balance from the network from a given XOR/NRS-URL and secret key string.
+        /// The difference between this and 'keys_balance_from_sk' function is that this will additionally
+        /// check that the XOR/NRS-URL corresponds to the public key derived from the provided secret key.
+        /// </summary>
+        /// <param name="url">The XOR url.</param>
+        /// <param name="sk">The secret key.</param>
+        /// <returns>The balance.</returns>
         public Task<string> KeysBalanceFromUrlAsync(string url, string sk)
             => AppBindings.KeysBalanceFromUrlAsync(ref _appPtr, url, sk);
 
+        /// <summary>
+        /// Check that the XOR/NRS-URL corresponds to the public key derived from the provided secret key.
+        /// </summary>
+        /// <param name="url">The XOR url.</param>
+        /// <param name="sk">The secret key.</param>
+        /// <returns>The public key derived from the secret key.</returns>
         public Task<string> ValidateSkForUrlAsync(string sk, string url)
             => AppBindings.ValidateSkForUrlAsync(ref _appPtr, sk, url);
 
+        /// <summary>
+        /// Transfers safecoins from one SafeKey to another, or to a Wallet.
+        /// </summary>
+        /// <param name="amount">The amount to transfer.</param>
+        /// <param name="fromSk">The sender secret key.</param>
+        /// <param name="toUrl">The reipient XOR url.</param>
+        /// <param name="txId">An optional transaction id. A random will be returned if none specified. </param>
+        /// <returns></returns>
         public Task<ulong> KeysTransferAsync(string amount, string fromSk, string toUrl, ulong txId)
             => AppBindings.KeysTransferAsync(ref _appPtr, amount, fromSk, toUrl, txId);
     }

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -26,7 +26,7 @@ namespace SafeApp.API
         /// </summary>
         /// <returns>Key pair.</returns>
         public Task<BlsKeyPair> GenerateKeyPairAsync()
-            => AppBindings.GenerateKeyPairAsync(ref _appPtr);
+            => AppBindings.GenerateKeyPairAsync(_appPtr);
 
         /// <summary>
         /// Create a SafeKey on the network and returns its XOR-URL.
@@ -41,7 +41,7 @@ namespace SafeApp.API
             string from,
             string preloadAmount,
             string pk)
-            => AppBindings.CreateKeysAsync(ref _appPtr, from, preloadAmount, pk);
+            => AppBindings.CreateKeysAsync(_appPtr, from, preloadAmount, pk);
 
         /// <summary>
         /// Create a SafeKey on the network, allocates testcoins onto it, and return the SafeKey's XOR-URL.
@@ -49,7 +49,7 @@ namespace SafeApp.API
         /// <param name="preloadAmount">Amount of funds to send.</param>
         /// <returns>XOR url of the balance, and a new key pair.</returns>
         public Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(string preloadAmount)
-            => AppBindings.KeysCreatePreloadTestCoinsAsync(ref _appPtr, preloadAmount);
+            => AppBindings.KeysCreatePreloadTestCoinsAsync(_appPtr, preloadAmount);
 
         /// <summary>
         /// Check SafeKey's balance from the network from a given SecretKey string.
@@ -57,7 +57,7 @@ namespace SafeApp.API
         /// <param name="sk">The secret key.</param>
         /// <returns>The balance.</returns>
         public Task<string> KeysBalanceFromSkAsync(string sk)
-            => AppBindings.KeysBalanceFromSkAsync(ref _appPtr, sk);
+            => AppBindings.KeysBalanceFromSkAsync(_appPtr, sk);
 
         /// <summary>
         /// Check SafeKey's balance from the network from a given XOR/NRS-URL and secret key string.
@@ -68,7 +68,7 @@ namespace SafeApp.API
         /// <param name="sk">The secret key.</param>
         /// <returns>The balance.</returns>
         public Task<string> KeysBalanceFromUrlAsync(string url, string sk)
-            => AppBindings.KeysBalanceFromUrlAsync(ref _appPtr, url, sk);
+            => AppBindings.KeysBalanceFromUrlAsync(_appPtr, url, sk);
 
         /// <summary>
         /// Check that the XOR/NRS-URL corresponds to the public key derived from the provided secret key.
@@ -77,7 +77,7 @@ namespace SafeApp.API
         /// <param name="sk">The secret key.</param>
         /// <returns>The public key derived from the secret key.</returns>
         public Task<string> ValidateSkForUrlAsync(string sk, string url)
-            => AppBindings.ValidateSkForUrlAsync(ref _appPtr, sk, url);
+            => AppBindings.ValidateSkForUrlAsync(_appPtr, sk, url);
 
         /// <summary>
         /// Transfers safecoins from one SafeKey to another, or to a Wallet.
@@ -88,6 +88,6 @@ namespace SafeApp.API
         /// <param name="txId">An optional transaction id. A random will be returned if none specified. </param>
         /// <returns></returns>
         public Task<ulong> KeysTransferAsync(string amount, string fromSk, string toUrl, ulong txId)
-            => AppBindings.KeysTransferAsync(ref _appPtr, amount, fromSk, toUrl, txId);
+            => AppBindings.KeysTransferAsync(_appPtr, amount, fromSk, toUrl, txId);
     }
 }

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -48,5 +48,8 @@ namespace SafeApp.API
 
         public Task<string> KeysBalanceFromSkAsync(string sk)
             => AppBindings.KeysBalanceFromSkAsync(ref _appPtr, sk);
+
+        public Task<string> KeysBalanceFromUrlAsync(string url, string sk)
+            => AppBindings.KeysBalanceFromUrlAsync(ref _appPtr, url, sk);
     }
 }

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -51,5 +51,8 @@ namespace SafeApp.API
 
         public Task<string> KeysBalanceFromUrlAsync(string url, string sk)
             => AppBindings.KeysBalanceFromUrlAsync(ref _appPtr, url, sk);
+
+        public Task<string> ValidateSkForUrlAsync(string sk, string url)
+            => AppBindings.ValidateSkForUrlAsync(ref _appPtr, sk, url);
     }
 }

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -45,5 +45,8 @@ namespace SafeApp.API
 
         public Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(string preloadAmount)
             => AppBindings.KeysCreatePreloadTestCoinsAsync(ref _appPtr, preloadAmount);
+
+        public Task<string> KeysBalanceFromSkAsync(string sk)
+            => AppBindings.KeysBalanceFromSkAsync(ref _appPtr, sk);
     }
 }

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -27,5 +27,20 @@ namespace SafeApp.API
         /// <returns>Key pair.</returns>
         public Task<BlsKeyPair> GenerateKeyPairAsync()
             => AppBindings.GenerateKeyPairAsync(ref _appPtr);
+
+        /// <summary>
+        /// Create a SafeKey on the network and returns its XOR-URL.
+        /// Optionally pre-loads it with an amount.
+        /// Also returns new key pair if a recipient public key was not provided.
+        /// </summary>
+        /// <param name="from">Secret key of source funds.</param>
+        /// <param name="preloadAmount">Optional amount of funds to send.</param>
+        /// <param name="pk">Public key of recipient if provided.</param>
+        /// <returns>Xor url of the balance, and a new key pair if no public key was provided.</returns>
+        public Task<(string, BlsKeyPair?)> CreateKeysAsync(
+            string from,
+            string preloadAmount,
+            string pk)
+            => AppBindings.CreateKeysAsync(ref _appPtr, from, preloadAmount, pk);
     }
 }

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using SafeApp.AppBindings;
+using SafeApp.Core;
+
+namespace SafeApp.API
+{
+    /// <summary>
+    /// Keys API.
+    /// </summary>
+    public class Keys
+    {
+        static readonly IAppBindings AppBindings = AppResolver.Current;
+        IntPtr _appPtr;
+
+        /// <summary>
+        /// Initializes an Keys object for the Session instance.
+        /// The app pointer is required to perform network operations.
+        /// </summary>
+        /// <param name="appPtr">SafeApp pointer.</param>
+        internal Keys(SafeAppPtr appPtr)
+            => _appPtr = appPtr;
+
+        /// <summary>
+        /// Generate a key pair without creating and/or storing a SafeKey on the network.
+        /// </summary>
+        /// <returns>Key pair.</returns>
+        public Task<BlsKeyPair> GenerateKeyPairAsync()
+            => AppBindings.GenerateKeyPairAsync(ref _appPtr);
+    }
+}

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -37,7 +37,7 @@ namespace SafeApp.API
         /// <param name="preloadAmount">Optional amount of funds to send.</param>
         /// <param name="pk">Public key of recipient if provided.</param>
         /// <returns>XOR url of the balance, and a new key pair if no public key was provided.</returns>
-        public Task<(string, BlsKeyPair?)> CreateKeysAsync(
+        public Task<(string, BlsKeyPair)> CreateKeysAsync(
             string from,
             string preloadAmount,
             string pk)

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -42,5 +42,8 @@ namespace SafeApp.API
             string preloadAmount,
             string pk)
             => AppBindings.CreateKeysAsync(ref _appPtr, from, preloadAmount, pk);
+
+        public Task<(string, BlsKeyPair)> KeysCreatePreloadTestCoinsAsync(string preloadAmount)
+            => AppBindings.KeysCreatePreloadTestCoinsAsync(ref _appPtr, preloadAmount);
     }
 }

--- a/SafeApp/Session.cs
+++ b/SafeApp/Session.cs
@@ -24,6 +24,8 @@ namespace SafeApp
 
         public Fetch Fetch { get; private set; }
 
+        public Keys Keys { get; private set; }
+
         /// <summary>
         /// Event triggered if session is disconnected from the network.
         /// </summary>
@@ -226,6 +228,7 @@ namespace SafeApp
             _disconnectedHandle = disconnectedHandle;
 
             Fetch = new Fetch(_appPtr);
+            Keys = new Keys(_appPtr);
         }
 
         /// <summary>

--- a/Tests/SafeApp.Tests/KeyTest.cs
+++ b/Tests/SafeApp.Tests/KeyTest.cs
@@ -83,5 +83,15 @@ namespace SafeApp.Tests
 
             var balance = await api.KeysBalanceFromUrlAsync(xorurl, keyPair.SK);
         }
+
+        [Test]
+        public async Task ValidateSkForUrlTest()
+        {
+            var session = await TestUtils.CreateTestApp();
+            var api = session.Keys;
+            var (xorurl, keyPair) = await api.KeysCreatePreloadTestCoinsAsync("1");
+
+            var publicKey = await api.ValidateSkForUrlAsync(keyPair.SK, xorurl);
+        }
     }
 }

--- a/Tests/SafeApp.Tests/KeyTest.cs
+++ b/Tests/SafeApp.Tests/KeyTest.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace SafeApp.Tests
+{
+    [TestFixture]
+    internal class KeyTest
+    {
+        [Test]
+        public async Task GenerateKeyPairTest()
+        {
+            var session = await TestUtils.CreateTestApp();
+            var api = session.Keys;
+            var keyPair = await api.GenerateKeyPairAsync();
+        }
+    }
+}

--- a/Tests/SafeApp.Tests/KeyTest.cs
+++ b/Tests/SafeApp.Tests/KeyTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SafeApp.Core;
 
 namespace SafeApp.Tests
 {
@@ -14,5 +15,36 @@ namespace SafeApp.Tests
             var api = session.Keys;
             var keyPair = await api.GenerateKeyPairAsync();
         }
+
+        [Test]
+        public async Task CreateKeysTest()
+        {
+            var sessionSender = await GetSessionAsync();
+            var apiSender = sessionSender.Keys;
+            var keyPairSender = await apiSender.GenerateKeyPairAsync();
+
+            var sessionRecipient = await GetSessionAsync();
+            var apiRecipient = sessionRecipient.Keys;
+            var keyPairRecipient = await apiRecipient.GenerateKeyPairAsync();
+
+            var (xorUrl, newKeyPair) = await apiSender.CreateKeysAsync(
+                keyPairSender.SK,
+                "1",
+                keyPairRecipient.PK);
+        }
+
+        Task<Session> GetSessionAsync()
+            => TestUtils.CreateTestApp(new AuthReq
+            {
+                App = new AppExchangeInfo
+                {
+                    Id = "net.maidsafe.test",
+                    Name = "TestApp",
+                    Scope = null,
+                    Vendor = "MaidSafe.net Ltd."
+                },
+                AppContainer = true,
+                Containers = new List<ContainerPermissions>()
+            });
     }
 }

--- a/Tests/SafeApp.Tests/KeyTest.cs
+++ b/Tests/SafeApp.Tests/KeyTest.cs
@@ -46,5 +46,22 @@ namespace SafeApp.Tests
                 AppContainer = true,
                 Containers = new List<ContainerPermissions>()
             });
+
+        [Test]
+        public async Task KeysCreatePreloadTestCoinsTest()
+        {
+            var session = await TestUtils.CreateTestApp();
+            var api = session.Keys;
+
+            var (xorurl, keyPair) = await api.KeysCreatePreloadTestCoinsAsync("1");
+
+            Assert.IsNotNull(xorurl);
+            Assert.IsNotNull(keyPair.PK);
+            Assert.IsNotNull(keyPair.SK);
+            Assert.AreNotSame(string.Empty, keyPair.PK);
+            Assert.AreNotSame(string.Empty, keyPair.SK);
+
+            // Todo: replace with call to api.ValidateKeys
+        }
     }
 }

--- a/Tests/SafeApp.Tests/KeyTest.cs
+++ b/Tests/SafeApp.Tests/KeyTest.cs
@@ -63,5 +63,15 @@ namespace SafeApp.Tests
 
             // Todo: replace with call to api.ValidateKeys
         }
+
+        [Test]
+        public async Task KeysBalanceFromSkTest()
+        {
+            var session = await TestUtils.CreateTestApp();
+            var api = session.Keys;
+            var (xorurl, keyPair) = await api.KeysCreatePreloadTestCoinsAsync("1");
+
+            var balance = await api.KeysBalanceFromSkAsync(keyPair.SK);
+        }
     }
 }

--- a/Tests/SafeApp.Tests/KeyTest.cs
+++ b/Tests/SafeApp.Tests/KeyTest.cs
@@ -53,15 +53,17 @@ namespace SafeApp.Tests
             var session = await TestUtils.CreateTestApp();
             var api = session.Keys;
 
-            var (xorurl, keyPair) = await api.KeysCreatePreloadTestCoinsAsync("1");
+            var (xorUrl, keyPair) = await api.KeysCreatePreloadTestCoinsAsync("1");
 
-            Assert.IsNotNull(xorurl);
+            Assert.IsNotNull(xorUrl);
             Assert.IsNotNull(keyPair.PK);
             Assert.IsNotNull(keyPair.SK);
             Assert.AreNotSame(string.Empty, keyPair.PK);
             Assert.AreNotSame(string.Empty, keyPair.SK);
 
-            // Todo: replace with call to api.ValidateKeys
+            var publicKey = await api.ValidateSkForUrlAsync(keyPair.SK, xorUrl);
+
+            Assert.AreEqual(keyPair.PK, publicKey);
         }
 
         [Test]

--- a/Tests/SafeApp.Tests/KeyTest.cs
+++ b/Tests/SafeApp.Tests/KeyTest.cs
@@ -73,5 +73,15 @@ namespace SafeApp.Tests
 
             var balance = await api.KeysBalanceFromSkAsync(keyPair.SK);
         }
+
+        [Test]
+        public async Task KeysBalanceFromUrlTest()
+        {
+            var session = await TestUtils.CreateTestApp();
+            var api = session.Keys;
+            var (xorurl, keyPair) = await api.KeysCreatePreloadTestCoinsAsync("1");
+
+            var balance = await api.KeysBalanceFromUrlAsync(xorurl, keyPair.SK);
+        }
     }
 }

--- a/Tests/SafeApp.Tests/KeyTest.cs
+++ b/Tests/SafeApp.Tests/KeyTest.cs
@@ -93,5 +93,24 @@ namespace SafeApp.Tests
 
             var publicKey = await api.ValidateSkForUrlAsync(keyPair.SK, xorurl);
         }
+
+        [Test]
+        public async Task KeysTransferTest()
+        {
+            var amountToSend = "1";
+            var txId = 1234UL;
+
+            var sessionSender = await GetSessionAsync();
+            var apiSender = sessionSender.Keys;
+            var (_, keyPairSender) = await apiSender.KeysCreatePreloadTestCoinsAsync(amountToSend);
+
+            var sessionRecipient = await GetSessionAsync();
+            var apiRecipient = sessionRecipient.Keys;
+            var (recipientUrl, keyPairRecipient) = await apiRecipient.KeysCreatePreloadTestCoinsAsync("0.1");
+
+            var resultTxId = await apiSender.KeysTransferAsync("1", keyPairSender.SK, recipientUrl, txId);
+
+            Assert.AreEqual(txId, resultTxId);
+        }
     }
 }

--- a/Tests/SafeApp.Tests/SafeApp.Tests.projitems
+++ b/Tests/SafeApp.Tests/SafeApp.Tests.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>SafeApp.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)KeyTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AuthTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MiscTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestUtils.cs" />


### PR DESCRIPTION
Fixes : #95
This adds `Keys` APIs.

Following APIs are added:

 - `GenerateKeyPairAsync`
 - `CreateKeysAsync`
 - `KeysCreatePreloadTestCoinsAsync`
 - `KeysBalanceFromSkAsync`
 - `KeysBalanceFromUrlAsync`
 - `ValidateSkForUrlAsync`
 - `KeysTransferAsync`