### PR TITLE
New libs from s3

### DIFF
--- a/CakeHelperScripts/NativeScriptDownloader.cake
+++ b/CakeHelperScripts/NativeScriptDownloader.cake
@@ -1,4 +1,4 @@
-var TAG = "0.9.1";
+var TAG = "0.4.0";
 var LIB_DIR_NAME = "SafeApp.AppBindings/NativeLibs/";
 var ANDROID_DIR_NAME = $"{LIB_DIR_NAME}Android";
 var IOS_DIR_NAME = $"{LIB_DIR_NAME}iOS";
@@ -52,13 +52,14 @@ Task("Download-Libs")
 
       foreach(var target in targets) {
         var targetDirectory = string.Format("{0}/{1}/{2}", Native_DIR.Path, item, target);
-        var mockZipFilename = string.Format("safe_app-mock-{0}-{1}.zip", TAG, target);
-        var nonMockZipFilename = string.Format("safe_app-{0}-{1}.zip", TAG, target);
-        var mockZipUrl = string.Format("https://s3.eu-west-2.amazonaws.com/safe-client-libs/{0}", mockZipFilename);
-        var nonMockZipUrl = string.Format("https://s3.eu-west-2.amazonaws.com/safe-client-libs/{0}", nonMockZipFilename);
+        var mockZipFilename = string.Format("safe-api-mock-{0}-{1}.zip", TAG, target);
+        var nonMockZipFilename = string.Format("safe-api-{0}-{1}.zip", TAG, target);
+        var mockZipUrl = string.Format("https://safe-api-native-libs.s3.eu-west-2.amazonaws.com/{0}", mockZipFilename);
+        var nonMockZipUrl = string.Format("https://safe-api-native-libs.s3.eu-west-2.amazonaws.com/{0}", nonMockZipFilename);
         var mockZipSavePath = string.Format("{0}/{1}/{2}/{3}", Native_DIR.Path, item, target, mockZipFilename);
         var nonMockZipSavePath = string.Format("{0}/{1}/{2}/{3}", Native_DIR.Path, item, target, nonMockZipFilename);
 
+Information(mockZipSavePath);
         if(!DirectoryExists(targetDirectory))
           CreateDirectory(targetDirectory);
         else
@@ -148,13 +149,6 @@ Task("UnZip-Libs")
             platformOutputDirectory.Append("/x86_64");
 
           Unzip(zip, platformOutputDirectory.ToString());
-
-          if(target.Contains("osx") || target.Contains("android") || target.Contains("linux"))
-          {
-            var aFile = GetFiles(string.Format("{0}/*.a", platformOutputDirectory.ToString()));
-            if(aFile.Count > 0)
-              DeleteFile(aFile.ToArray()[0].FullPath);
-          }
         }
       }
     }

--- a/CakeHelperScripts/NativeScriptDownloader.cake
+++ b/CakeHelperScripts/NativeScriptDownloader.cake
@@ -59,7 +59,6 @@ Task("Download-Libs")
         var mockZipSavePath = string.Format("{0}/{1}/{2}/{3}", Native_DIR.Path, item, target, mockZipFilename);
         var nonMockZipSavePath = string.Format("{0}/{1}/{2}/{3}", Native_DIR.Path, item, target, nonMockZipFilename);
 
-Information(mockZipSavePath);
         if(!DirectoryExists(targetDirectory))
           CreateDirectory(targetDirectory);
         else

--- a/SafeApp.AppBindings/AppBindings.cs
+++ b/SafeApp.AppBindings/AppBindings.cs
@@ -22,7 +22,7 @@ namespace SafeApp.AppBindings
 #if __IOS__
         private const string DllName = "__Internal";
 #else
-        private const string DllName = "safe_api_ffi";
+        private const string DllName = "safe_api";
 #endif
 
         public bool IsMockBuild()

--- a/SafeApp.AppBindings/SafeApp.AppBindings.csproj
+++ b/SafeApp.AppBindings/SafeApp.AppBindings.csproj
@@ -12,7 +12,6 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType Condition=" !$(TargetFramework.StartsWith('MonoAndroid')) ">portable</DebugType>
     <DebugType Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">Full</DebugType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'netcoreapp1.0' ">

--- a/SafeApp.AppBindings/Targets/Android.targets
+++ b/SafeApp.AppBindings/Targets/Android.targets
@@ -17,7 +17,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\armeabi-v7a\libsafe_app.so" />
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\x86_64\libsafe_app.so" />
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\armeabi-v7a\libsafe_api.so" />
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\x86_64\libsafe_api.so" />
   </ItemGroup>
 </Project>

--- a/SafeApp.AppBindings/Targets/NetCore.targets
+++ b/SafeApp.AppBindings/Targets/NetCore.targets
@@ -19,17 +19,17 @@
   <Choose>
     <When Condition="$(RuntimeIdentifier.StartsWith('win'))">
       <PropertyGroup>
-        <NativeLibFile>safe_app.dll</NativeLibFile>
+        <NativeLibFile>safe_api.dll</NativeLibFile>
       </PropertyGroup>
     </When>
     <When Condition="$(RuntimeIdentifier.StartsWith('osx'))">
       <PropertyGroup>
-        <NativeLibFile>libsafe_app.dylib</NativeLibFile>
+        <NativeLibFile>libsafe_api.dylib</NativeLibFile>
       </PropertyGroup>
     </When>
     <When Condition="'$(RuntimeIdentifier)' != ''">
       <PropertyGroup>
-        <NativeLibFile>libsafe_app.so</NativeLibFile>
+        <NativeLibFile>libsafe_api.so</NativeLibFile>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/SafeApp.AppBindings/Targets/iOS.targets
+++ b/SafeApp.AppBindings/Targets/iOS.targets
@@ -17,7 +17,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <NativeReference Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\libsafe_app.a">
+    <NativeReference Include="$(MSBuildThisFileDirectory)lib\$(NativeLibType)\libsafe_api.a">
       <Kind>Static</Kind>
       <ForceLoad>True</ForceLoad>
       <LinkerFlags>-lresolv</LinkerFlags>

--- a/SafeApp.Core/SafeApp.Core.csproj
+++ b/SafeApp.Core/SafeApp.Core.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.3\SafeApp.Core.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SafeApp.MockAuthBindings/AuthBindings.cs
+++ b/SafeApp.MockAuthBindings/AuthBindings.cs
@@ -16,7 +16,7 @@ namespace SafeApp.MockAuthBindings
 #if __IOS__
         private const string DllName = "__Internal";
 #else
-        private const string DllName = "safe_api_ffi";
+        private const string DllName = "safe_api";
 #endif
 
         public bool IsMockBuild()

--- a/SafeApp.MockAuthBindings/SafeApp.MockAuthBindings.csproj
+++ b/SafeApp.MockAuthBindings/SafeApp.MockAuthBindings.csproj
@@ -20,7 +20,6 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType Condition=" !$(TargetFramework.StartsWith('MonoAndroid')) ">portable</DebugType>
     <DebugType Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">Full</DebugType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'netcoreapp1.0' ">

--- a/SafeApp.nuspec
+++ b/SafeApp.nuspec
@@ -120,8 +120,8 @@
 
     <!--Desktop - NetFramework-->
     <file src="SafeApp.AppBindings\Targets\NetFramework.targets" target="build\net46\MaidSafe.SafeApp.targets" />
-    <file src="SafeApp.AppBindings\NativeLibs\Desktop\mock\safe_app.dll" target="build\net46\lib\mock\safe_app.dll" />
-    <file src="SafeApp.AppBindings\NativeLibs\Desktop\non-mock\safe_app.dll" target="build\net46\lib\non-mock\safe_app.dll" />
+    <file src="SafeApp.AppBindings\NativeLibs\Desktop\mock\safe_api.dll" target="build\net46\lib\mock\safe_api.dll" />
+    <file src="SafeApp.AppBindings\NativeLibs\Desktop\non-mock\safe_api.dll" target="build\net46\lib\non-mock\safe_api.dll" />
     <file src="SafeApp\bin\Release\netstandard1.3\SafeApp.dll" target="lib\net46\SafeApp.dll" />
     <file src="SafeApp\bin\Release\netstandard1.3\SafeApp.pdb" target="lib\net46\SafeApp.pdb" />
     <file src="SafeApp\bin\Release\netstandard1.3\SafeApp.xml" target="lib\net46\SafeApp.xml" />

--- a/SafeApp/SafeApp.csproj
+++ b/SafeApp/SafeApp.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.3\SafeApp.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/SafeApp.Tests.Android/SafeApp.Tests.Android.csproj
+++ b/Tests/SafeApp.Tests.Android/SafeApp.Tests.Android.csproj
@@ -70,11 +70,11 @@
     <Compile Include="Resources\Resource.Designer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <AndroidNativeLibrary Include="..\..\SafeApp.AppBindings\NativeLibs\Android\mock\armeabi-v7a\libsafe_app.so">
-      <Link>lib\armeabi-v7a\libsafe_app.so</Link>
+    <AndroidNativeLibrary Include="..\..\SafeApp.AppBindings\NativeLibs\Android\mock\armeabi-v7a\libsafe_api.so">
+      <Link>lib\armeabi-v7a\libsafe_api.so</Link>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="..\..\SafeApp.AppBindings\NativeLibs\Android\mock\x86_64\libsafe_app.so">
-      <Link>lib\x86_64\libsafe_app.so</Link>
+    <AndroidNativeLibrary Include="..\..\SafeApp.AppBindings\NativeLibs\Android\mock\x86_64\libsafe_api.so">
+      <Link>lib\x86_64\libsafe_api.so</Link>
     </AndroidNativeLibrary>
     <AndroidAsset Include="..\SafeApp.Tests\log.toml">
       <Link>Assets\log.toml</Link>

--- a/Tests/SafeApp.Tests.Core/SafeApp.Tests.Core.csproj
+++ b/Tests/SafeApp.Tests.Core/SafeApp.Tests.Core.csproj
@@ -24,13 +24,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\libsafe_app.dylib" Link="libsafe_app.dylib" Condition=" $(IsOSX) == 'true' ">
+    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\libsafe_api.dylib" Link="libsafe_api.dylib" Condition=" $(IsOSX) == 'true' ">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\libsafe_app.so" Link="libsafe_app.so" Condition=" $(IsLinux) == 'true' ">
+    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\libsafe_api.so" Link="libsafe_api.so" Condition=" $(IsLinux) == 'true' ">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\safe_app.dll" Link="safe_app.dll" Condition=" $(IsWindows) == 'true' ">
+    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\safe_api.dll" Link="safe_api.dll" Condition=" $(IsWindows) == 'true' ">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="..\SafeApp.Tests\log.toml" Link="log.toml">

--- a/Tests/SafeApp.Tests.Framework/SafeApp.Tests.Framework.csproj
+++ b/Tests/SafeApp.Tests.Framework/SafeApp.Tests.Framework.csproj
@@ -82,8 +82,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\safe_app.dll">
-      <Link>safe_app.dll</Link>
+    <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\safe_api.dll">
+      <Link>safe_api.dll</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Tests/SafeApp.Tests.iOS/SafeApp.Tests.iOS.csproj
+++ b/Tests/SafeApp.Tests.iOS/SafeApp.Tests.iOS.csproj
@@ -127,7 +127,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\SafeApp.AppBindings\NativeLibs\iOS\mock\libsafe_app.a">
+    <NativeReference Include="..\..\SafeApp.AppBindings\NativeLibs\iOS\mock\libsafe_api.a">
       <Kind>Static</Kind>
       <ForceLoad>True</ForceLoad>
       <LinkerFlags>-lresolv</LinkerFlags>


### PR DESCRIPTION
**Changes**
- Downloading new libs from S3
- Using `safe_api` instead of `safe_app` and also it seems better choice then `safe_api_ffi`

**Note**
- Android libs are just copy of linux ones, I will upload correct libs on Monday
- All the libs are mock only, non-mock will also be uploaded next week
- The links will have to be updated later next week once we have Jenkins setup