### PR TITLE
fix: do not pass IntPtr with ref keyword

### DIFF
--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -20,11 +20,11 @@ namespace SafeApp.AppBindings
 
         Task AppSetAdditionalSearchPathAsync(string newPath);
 
-        Task<(uint, string)> EncodeAuthReqAsync(ref AuthReq req);
+        Task<(uint, string)> EncodeAuthReqAsync(AuthReq req);
 
-        Task<(uint, string)> EncodeContainersReqAsync(ref ContainersReq req);
+        Task<(uint, string)> EncodeContainersReqAsync(ContainersReq req);
 
-        Task<(uint, string)> EncodeShareMDataReqAsync(ref ShareMDataReq req);
+        Task<(uint, string)> EncodeShareMDataReqAsync(ShareMDataReq req);
 
         Task<(uint, string)> EncodeUnregisteredReqAsync(byte[] extraData);
 
@@ -42,7 +42,7 @@ namespace SafeApp.AppBindings
         #region XorEncoder
 
         Task<string> XorurlEncodeAsync(
-            ref byte[] name,
+            byte[] name,
             ulong typeTag,
             ulong dataType,
             ushort contentType,
@@ -52,7 +52,7 @@ namespace SafeApp.AppBindings
             string baseEncoding);
 
         Task<XorUrlEncoder> XorurlEncoderAsync(
-            ref byte[] name,
+            byte[] name,
             ulong typeTag,
             ulong dataType,
             ushort contentType,
@@ -66,7 +66,7 @@ namespace SafeApp.AppBindings
 
         #region Fetch
 
-        Task<ISafeData> FetchAsync(ref IntPtr app, string uri);
+        Task<ISafeData> FetchAsync(IntPtr app, string uri);
 
         #endregion
     }

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -45,7 +45,7 @@ namespace SafeApp.AppBindings
 
         #region XorUrl
         public Task<string> XorurlEncodeAsync(
-            ref byte[] name,
+            byte[] name,
             ulong typeTag,
             ulong dataType,
             ushort contentType,
@@ -56,7 +56,7 @@ namespace SafeApp.AppBindings
         {
             var (ret, userData) = BindingUtils.PrepareTask<string>();
             XorurlEncodeNative(
-                ref name,
+                name,
                 typeTag,
                 dataType,
                 contentType,
@@ -71,7 +71,7 @@ namespace SafeApp.AppBindings
 
         [DllImport(DllName, EntryPoint = "xorurl_encode")]
         private static extern void XorurlEncodeNative(
-            ref byte[] name,
+            byte[] name,
             ulong typeTag,
             ulong dataType,
             ushort contentType,
@@ -83,7 +83,7 @@ namespace SafeApp.AppBindings
             FfiResultStringCb oCb);
 
         public Task<XorUrlEncoder> XorurlEncoderAsync(
-            ref byte[] name,
+            byte[] name,
             ulong typeTag,
             ulong dataType,
             ushort contentType,
@@ -93,7 +93,7 @@ namespace SafeApp.AppBindings
         {
             var (ret, userData) = BindingUtils.PrepareTask<XorUrlEncoder>();
             XorurlEncoderNative(
-                ref name,
+                name,
                 typeTag,
                 dataType,
                 contentType,
@@ -107,7 +107,7 @@ namespace SafeApp.AppBindings
 
         [DllImport(DllName, EntryPoint = "xorurl_encoder")]
         private static extern void XorurlEncoderNative(
-            ref byte[] name,
+            byte[] name,
             ulong typeTag,
             ulong dataType,
             ushort contentType,
@@ -149,11 +149,11 @@ namespace SafeApp.AppBindings
 
         #region Fetch
 
-        public Task<ISafeData> FetchAsync(ref IntPtr app, string url)
+        public Task<ISafeData> FetchAsync(IntPtr app, string url)
         {
             var (task, userData) = BindingUtils.PrepareTask<ISafeData>();
             FetchNative(
-              ref app,
+              app,
               url,
               userData,
               DelegateOnFfiResultPublishedImmutableDataCb,
@@ -166,7 +166,7 @@ namespace SafeApp.AppBindings
 
         [DllImport(DllName, EntryPoint = "fetch")]
         private static extern void FetchNative(
-            ref IntPtr app,
+            IntPtr app,
             [MarshalAs(UnmanagedType.LPStr)] string url,
             IntPtr userData,
             FfiResultPublishedImmutableDataCb oPublished,

--- a/SafeApp.AppBindings/AppBindings.cs
+++ b/SafeApp.AppBindings/AppBindings.cs
@@ -57,29 +57,29 @@ namespace SafeApp.AppBindings
             IntPtr userData,
             FfiResultCb oCb);
 
-        public Task<(uint, string)> EncodeAuthReqAsync(ref AuthReq req)
+        public Task<(uint, string)> EncodeAuthReqAsync(AuthReq req)
         {
             var reqNative = req.ToNative();
             var (ret, userData) = BindingUtils.PrepareTask<(uint, string)>();
-            EncodeAuthReqNative(ref reqNative, userData, DelegateOnFfiResultUIntStringCb);
+            EncodeAuthReqNative(reqNative, userData, DelegateOnFfiResultUIntStringCb);
             reqNative.Free();
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "encode_auth_req")]
-        private static extern void EncodeAuthReqNative(ref AuthReqNative req, IntPtr userData, FfiResultUIntStringCb oCb);
+        private static extern void EncodeAuthReqNative(AuthReqNative req, IntPtr userData, FfiResultUIntStringCb oCb);
 
-        public Task<(uint, string)> EncodeContainersReqAsync(ref ContainersReq req)
+        public Task<(uint, string)> EncodeContainersReqAsync(ContainersReq req)
         {
             var reqNative = req.ToNative();
             var (ret, userData) = BindingUtils.PrepareTask<(uint, string)>();
-            EncodeContainersReqNative(ref reqNative, userData, DelegateOnFfiResultUIntStringCb);
+            EncodeContainersReqNative(reqNative, userData, DelegateOnFfiResultUIntStringCb);
             reqNative.Free();
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "encode_containers_req")]
-        private static extern void EncodeContainersReqNative(ref ContainersReqNative req, IntPtr userData, FfiResultUIntStringCb oCb);
+        private static extern void EncodeContainersReqNative(ContainersReqNative req, IntPtr userData, FfiResultUIntStringCb oCb);
 
         public Task<(uint, string)> EncodeUnregisteredReqAsync(byte[] extraData)
         {
@@ -96,17 +96,17 @@ namespace SafeApp.AppBindings
             IntPtr userData,
             FfiResultUIntStringCb oCb);
 
-        public Task<(uint, string)> EncodeShareMDataReqAsync(ref ShareMDataReq req)
+        public Task<(uint, string)> EncodeShareMDataReqAsync(ShareMDataReq req)
         {
             var reqNative = req.ToNative();
             var (ret, userData) = BindingUtils.PrepareTask<(uint, string)>();
-            EncodeShareMDataReqNative(ref reqNative, userData, DelegateOnFfiResultUIntStringCb);
+            EncodeShareMDataReqNative(reqNative, userData, DelegateOnFfiResultUIntStringCb);
             reqNative.Free();
             return ret;
         }
 
         [DllImport(DllName, EntryPoint = "encode_share_mdata_req")]
-        private static extern void EncodeShareMDataReqNative(ref ShareMDataReqNative req, IntPtr userData, FfiResultUIntStringCb oCb);
+        private static extern void EncodeShareMDataReqNative(ShareMDataReqNative req, IntPtr userData, FfiResultUIntStringCb oCb);
 
         [DllImport(DllName, EntryPoint = "decode_ipc_msg")]
         private static extern void DecodeIpcMsgNative(

--- a/SafeApp.Core/AppTypes.HighLevel.cs
+++ b/SafeApp.Core/AppTypes.HighLevel.cs
@@ -102,7 +102,7 @@ namespace SafeApp.Core
 
         internal void Free()
         {
-            BindingUtils.FreeList(ref DataPtr, ref DataLen);
+            BindingUtils.FreeList(DataPtr, DataLen);
         }
     }
 

--- a/SafeApp.Core/AppTypes.cs
+++ b/SafeApp.Core/AppTypes.cs
@@ -138,7 +138,7 @@ namespace SafeApp.Core
         /// </summary>
         internal void Free()
         {
-            BindingUtils.FreeList(ref ContainersPtr, ref ContainersLen);
+            BindingUtils.FreeList(ContainersPtr, ContainersLen);
         }
     }
 
@@ -368,7 +368,7 @@ namespace SafeApp.Core
         /// </summary>
         internal void Free()
         {
-            BindingUtils.FreeList(ref ContainersPtr, ref ContainersLen);
+            BindingUtils.FreeList(ContainersPtr, ContainersLen);
         }
     }
 
@@ -445,7 +445,7 @@ namespace SafeApp.Core
         /// </summary>
         internal void Free()
         {
-            BindingUtils.FreeList(ref ContainersPtr, ref ContainersLen);
+            BindingUtils.FreeList(ContainersPtr, ContainersLen);
         }
     }
 
@@ -572,7 +572,7 @@ namespace SafeApp.Core
         /// </summary>
         internal void Free()
         {
-            BindingUtils.FreeList(ref MDataPtr, ref MDataLen);
+            BindingUtils.FreeList(MDataPtr, MDataLen);
         }
     }
 
@@ -697,7 +697,7 @@ namespace SafeApp.Core
         internal void Free()
         {
             AccessContainerEntry.Free();
-            BindingUtils.FreeList(ref BootstrapConfigPtr, ref BootstrapConfigLen);
+            BindingUtils.FreeList(BootstrapConfigPtr, BootstrapConfigLen);
         }
     }
 

--- a/SafeApp.Core/BindingUtils.cs
+++ b/SafeApp.Core/BindingUtils.cs
@@ -153,7 +153,7 @@ namespace SafeApp.Core
         }
 
         // ReSharper disable once RedundantAssignment
-        public static void FreeList(ref IntPtr ptr, ref UIntPtr len)
+        public static void FreeList(IntPtr ptr, UIntPtr len)
         {
             if (ptr != IntPtr.Zero)
             {

--- a/SafeApp.MockAuthBindings/Abstraction/IAuthBindings.cs
+++ b/SafeApp.MockAuthBindings/Abstraction/IAuthBindings.cs
@@ -33,11 +33,11 @@ namespace SafeApp.MockAuthBindings
 
         Task AuthSetAdditionalSearchPathAsync(string newPath);
 
-        Task<string> EncodeAuthRespAsync(IntPtr auth, ref AuthReq req, uint reqId, bool isGranted);
+        Task<string> EncodeAuthRespAsync(IntPtr auth, AuthReq req, uint reqId, bool isGranted);
 
-        Task<string> EncodeContainersRespAsync(IntPtr auth, ref ContainersReq req, uint reqId, bool isGranted);
+        Task<string> EncodeContainersRespAsync(IntPtr auth, ContainersReq req, uint reqId, bool isGranted);
 
-        Task<string> EncodeShareMDataRespAsync(IntPtr auth, ref ShareMDataReq req, uint reqId, bool isGranted);
+        Task<string> EncodeShareMDataRespAsync(IntPtr auth, ShareMDataReq req, uint reqId, bool isGranted);
 
         Task<string> EncodeUnregisteredRespAsync(uint reqId, bool isGranted);
 

--- a/SafeApp.MockAuthBindings/AuthBindings.cs
+++ b/SafeApp.MockAuthBindings/AuthBindings.cs
@@ -153,11 +153,11 @@ namespace SafeApp.MockAuthBindings
             UIntShareMDataReqMetadataResponseListCb oShareMData,
             FfiResultStringCb oErr);
 
-        public Task<string> EncodeShareMDataRespAsync(IntPtr auth, ref ShareMDataReq req, uint reqId, bool isGranted)
+        public Task<string> EncodeShareMDataRespAsync(IntPtr auth, ShareMDataReq req, uint reqId, bool isGranted)
         {
             var reqNative = req.ToNative();
             var (ret, userData) = BindingUtils.PrepareTask<string>();
-            EncodeShareMDataRespNative(auth, ref reqNative, reqId, isGranted, userData, DelegateOnFfiResultStringCb);
+            EncodeShareMDataRespNative(auth, reqNative, reqId, isGranted, userData, DelegateOnFfiResultStringCb);
             reqNative.Free();
             return ret;
         }
@@ -165,7 +165,7 @@ namespace SafeApp.MockAuthBindings
         [DllImport(DllName, EntryPoint = "encode_share_mdata_resp")]
         private static extern void EncodeShareMDataRespNative(
             IntPtr auth,
-            ref ShareMDataReqNative req,
+            ShareMDataReqNative req,
             uint reqId,
             [MarshalAs(UnmanagedType.U1)] bool isGranted,
             IntPtr userData,
@@ -209,11 +209,11 @@ namespace SafeApp.MockAuthBindings
             IntPtr userData,
             FfiResultStringCb oCb);
 
-        public Task<string> EncodeAuthRespAsync(IntPtr auth, ref AuthReq req, uint reqId, bool isGranted)
+        public Task<string> EncodeAuthRespAsync(IntPtr auth, AuthReq req, uint reqId, bool isGranted)
         {
             var reqNative = req.ToNative();
             var (ret, userData) = BindingUtils.PrepareTask<string>();
-            EncodeAuthRespNative(auth, ref reqNative, reqId, isGranted, userData, DelegateOnFfiResultStringCb);
+            EncodeAuthRespNative(auth, reqNative, reqId, isGranted, userData, DelegateOnFfiResultStringCb);
             reqNative.Free();
             return ret;
         }
@@ -221,17 +221,17 @@ namespace SafeApp.MockAuthBindings
         [DllImport(DllName, EntryPoint = "encode_auth_resp")]
         private static extern void EncodeAuthRespNative(
             IntPtr auth,
-            ref AuthReqNative req,
+            AuthReqNative req,
             uint reqId,
             [MarshalAs(UnmanagedType.U1)] bool isGranted,
             IntPtr userData,
             FfiResultStringCb oCb);
 
-        public Task<string> EncodeContainersRespAsync(IntPtr auth, ref ContainersReq req, uint reqId, bool isGranted)
+        public Task<string> EncodeContainersRespAsync(IntPtr auth, ContainersReq req, uint reqId, bool isGranted)
         {
             var reqNative = req.ToNative();
             var (ret, userData) = BindingUtils.PrepareTask<string>();
-            EncodeContainersRespNative(auth, ref reqNative, reqId, isGranted, userData, DelegateOnFfiResultStringCb);
+            EncodeContainersRespNative(auth, reqNative, reqId, isGranted, userData, DelegateOnFfiResultStringCb);
             reqNative.Free();
             return ret;
         }
@@ -239,7 +239,7 @@ namespace SafeApp.MockAuthBindings
         [DllImport(DllName, EntryPoint = "encode_containers_resp")]
         private static extern void EncodeContainersRespNative(
             IntPtr auth,
-            ref ContainersReqNative req,
+            ContainersReqNative req,
             uint reqId,
             [MarshalAs(UnmanagedType.U1)] bool isGranted,
             IntPtr userData,

--- a/SafeApp.MockAuthBindings/AuthTypes.cs
+++ b/SafeApp.MockAuthBindings/AuthTypes.cs
@@ -79,7 +79,7 @@ namespace SafeApp.MockAuthBindings
         // ReSharper disable once UnusedMember.Global
         internal void Free()
         {
-            BindingUtils.FreeList(ref ContainersPtr, ref ContainersLen);
+            BindingUtils.FreeList(ContainersPtr, ContainersLen);
         }
     }
 }

--- a/SafeApp.MockAuthBindings/Authenticator.cs
+++ b/SafeApp.MockAuthBindings/Authenticator.cs
@@ -249,7 +249,7 @@ namespace SafeApp.MockAuthBindings
         /// <returns>Encoded AuthIpcResponse string.</returns>
         public Task<string> EncodeAuthRespAsync(AuthIpcReq authIpcReq, bool allow)
         {
-            return NativeBindings.EncodeAuthRespAsync(_authPtr, ref authIpcReq.AuthReq, authIpcReq.ReqId, allow);
+            return NativeBindings.EncodeAuthRespAsync(_authPtr, authIpcReq.AuthReq, authIpcReq.ReqId, allow);
         }
 
         /// <summary>
@@ -260,7 +260,7 @@ namespace SafeApp.MockAuthBindings
         /// <returns>Encoded Containers permissions Response.</returns>
         public Task<string> EncodeContainersRespAsync(ContainersIpcReq req, bool allow)
         {
-            return NativeBindings.EncodeContainersRespAsync(_authPtr, ref req.ContainersReq, req.ReqId, allow);
+            return NativeBindings.EncodeContainersRespAsync(_authPtr, req.ContainersReq, req.ReqId, allow);
         }
 
         /// <summary>
@@ -271,7 +271,7 @@ namespace SafeApp.MockAuthBindings
         /// <returns>Encoded ShareMData response.</returns>
         public Task<string> EncodeShareMdataRespAsync(ShareMDataIpcReq req, bool allow)
         {
-            return NativeBindings.EncodeShareMDataRespAsync(_authPtr, ref req.ShareMDataReq, req.ReqId, allow);
+            return NativeBindings.EncodeShareMDataRespAsync(_authPtr, req.ShareMDataReq, req.ReqId, allow);
         }
 
         /// <summary>

--- a/SafeApp/API/Fetch.cs
+++ b/SafeApp/API/Fetch.cs
@@ -14,6 +14,6 @@ namespace SafeApp.API
             => _appPtr = appPtr;
 
         public Task<ISafeData> FetchAsync(string url)
-            => AppBindings.FetchAsync(ref _appPtr, url);
+            => AppBindings.FetchAsync(_appPtr, url);
     }
 }

--- a/SafeApp/API/XorEncoder.cs
+++ b/SafeApp/API/XorEncoder.cs
@@ -17,7 +17,7 @@ namespace SafeApp.API
             string subNames,
             ulong contentVersion,
             string baseEncoding)
-            => AppBindings.XorurlEncodeAsync(ref xorName, typeTag, dataType, contentType, path, subNames, contentVersion, baseEncoding);
+            => AppBindings.XorurlEncodeAsync(xorName, typeTag, dataType, contentType, path, subNames, contentVersion, baseEncoding);
 
         public static Task<XorUrlEncoder> EncodeAsync(
             byte[] xorName,
@@ -27,7 +27,7 @@ namespace SafeApp.API
             string path,
             string subNames,
             ulong contentVersion)
-            => AppBindings.XorurlEncoderAsync(ref xorName, typeTag, dataType, contentType, path, subNames, contentVersion);
+            => AppBindings.XorurlEncoderAsync(xorName, typeTag, dataType, contentType, path, subNames, contentVersion);
 
         public static Task<XorUrlEncoder> XorUrlEncoderFromUrl(string xorUrl)
             => AppBindings.XorurlEncoderFromUrlAsync(xorUrl);

--- a/SafeApp/Session.cs
+++ b/SafeApp/Session.cs
@@ -125,7 +125,7 @@ namespace SafeApp
         /// <returns>RequestId, Encoded authentication request.</returns>
         public static Task<(uint, string)> EncodeAuthReqAsync(AuthReq authReq)
         {
-            return AppBindings.EncodeAuthReqAsync(ref authReq);
+            return AppBindings.EncodeAuthReqAsync(authReq);
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace SafeApp
         /// <returns>Request Id, Encoded container request.</returns>
         public static Task<(uint, string)> EncodeContainerRequestAsync(ContainersReq containersReq)
         {
-            return AppBindings.EncodeContainersReqAsync(ref containersReq);
+            return AppBindings.EncodeContainersReqAsync(containersReq);
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace SafeApp
         /// <returns>Request Id, Encoded Mutable Data share request.</returns>
         public static Task<(uint, string)> EncodeShareMDataRequestAsync(ShareMDataReq shareMDataReq)
         {
-            return AppBindings.EncodeShareMDataReqAsync(ref shareMDataReq);
+            return AppBindings.EncodeShareMDataReqAsync(shareMDataReq);
         }
 
         /// <summary>


### PR DESCRIPTION
IntPtr is passed with ref keyword, which gives the address of the pointer and not the value of it, leading to `receiver is gone` error on native side.
FIX #111