### PR TITLE
refactor/api: use readonly app pointer

### DIFF
--- a/SafeApp/API/Fetch.cs
+++ b/SafeApp/API/Fetch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using SafeApp.AppBindings;
 using SafeApp.Core;
 
@@ -8,7 +7,7 @@ namespace SafeApp.API
     public class Fetch
     {
         static readonly IAppBindings AppBindings = AppResolver.Current;
-        IntPtr _appPtr;
+        readonly SafeAppPtr _appPtr;
 
         internal Fetch(SafeAppPtr appPtr)
             => _appPtr = appPtr;

--- a/SafeApp/API/Files.cs
+++ b/SafeApp/API/Files.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using SafeApp.AppBindings;
 using SafeApp.Core;
 
@@ -12,7 +10,7 @@ namespace SafeApp.API
     public class Files
     {
         static readonly IAppBindings AppBindings = AppResolver.Current;
-        IntPtr _appPtr;
+        readonly SafeAppPtr _appPtr;
 
         /// <summary>
         /// Initializes an Files object for the Session instance.

--- a/SafeApp/API/Keys.cs
+++ b/SafeApp/API/Keys.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using SafeApp.AppBindings;
 using SafeApp.Core;
 
@@ -11,7 +10,7 @@ namespace SafeApp.API
     public class Keys
     {
         static readonly IAppBindings AppBindings = AppResolver.Current;
-        IntPtr _appPtr;
+        readonly SafeAppPtr _appPtr;
 
         /// <summary>
         /// Initializes an Keys object for the Session instance.

--- a/SafeApp/API/Wallet.cs
+++ b/SafeApp/API/Wallet.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using SafeApp.AppBindings;
 using SafeApp.Core;
 
@@ -11,7 +10,7 @@ namespace SafeApp.API
     public class Wallet
     {
         static readonly IAppBindings AppBindings = AppResolver.Current;
-        IntPtr _appPtr;
+        readonly SafeAppPtr _appPtr;
 
         /// <summary>
         /// Initializes an Wallet object for the Session instance.


### PR DESCRIPTION
The private `IntPtr _appPtr` field is made `readonly` and of type `SafeAppPtr`.

Fixes #113 