### PR TITLE
refactor/bindings: use enums for content type and data type

### DIFF
--- a/SafeApp.AppBindings/Abstraction/IAppBindings.cs
+++ b/SafeApp.AppBindings/Abstraction/IAppBindings.cs
@@ -45,8 +45,8 @@ namespace SafeApp.AppBindings
         Task<string> XorurlEncodeAsync(
             byte[] name,
             ulong typeTag,
-            ulong dataType,
-            ushort contentType,
+            DataType dataType,
+            ContentType contentType,
             string path,
             string subNames,
             ulong contentVersion,
@@ -55,8 +55,8 @@ namespace SafeApp.AppBindings
         Task<XorUrlEncoder> XorurlEncoderAsync(
             byte[] name,
             ulong typeTag,
-            ulong dataType,
-            ushort contentType,
+            DataType dataType,
+            ContentType contentType,
             string path,
             string subNames,
             ulong contentVersion);

--- a/SafeApp.AppBindings/AppBindings.HighLevel.cs
+++ b/SafeApp.AppBindings/AppBindings.HighLevel.cs
@@ -47,8 +47,8 @@ namespace SafeApp.AppBindings
         public Task<string> XorurlEncodeAsync(
             byte[] name,
             ulong typeTag,
-            ulong dataType,
-            ushort contentType,
+            DataType dataType,
+            ContentType contentType,
             string path,
             string subNames,
             ulong contentVersion,
@@ -58,8 +58,8 @@ namespace SafeApp.AppBindings
             XorurlEncodeNative(
                 name,
                 typeTag,
-                dataType,
-                contentType,
+                (ulong)dataType,
+                (ushort)contentType,
                 path,
                 subNames,
                 contentVersion,
@@ -85,8 +85,8 @@ namespace SafeApp.AppBindings
         public Task<XorUrlEncoder> XorurlEncoderAsync(
             byte[] name,
             ulong typeTag,
-            ulong dataType,
-            ushort contentType,
+            DataType dataType,
+            ContentType contentType,
             string path,
             string subNames,
             ulong contentVersion)
@@ -95,8 +95,8 @@ namespace SafeApp.AppBindings
             XorurlEncoderNative(
                 name,
                 typeTag,
-                dataType,
-                contentType,
+                (ulong)dataType,
+                (ushort)contentType,
                 path,
                 subNames,
                 contentVersion,
@@ -140,7 +140,7 @@ namespace SafeApp.AppBindings
             BindingUtils.CompleteTask(
                 userData,
                 Marshal.PtrToStructure<FfiResult>(result),
-                () => Marshal.PtrToStructure<XorUrlEncoder>(xorurlEncoder));
+                () => new XorUrlEncoder(Marshal.PtrToStructure<XorUrlEncoderNative>(xorurlEncoder)));
         }
 
         private static readonly FfiResultXorUrlEncoderCb DelegateOnFfiResultXorUrlEncoderCb = OnFfiResultXorUrlEncoderCb;
@@ -209,7 +209,7 @@ namespace SafeApp.AppBindings
         private static void OnFfiResultSafeKeyCb(IntPtr userData, IntPtr safeKey)
         {
             var tcs = BindingUtils.FromHandlePtr<TaskCompletionSource<ISafeData>>(userData);
-            tcs.SetResult(Marshal.PtrToStructure<SafeKey>(safeKey));
+            tcs.SetResult(new SafeKey(Marshal.PtrToStructure<SafeKeyNative>(safeKey)));
         }
 
         private static readonly FfiResultSafeKeyCb DelegateOnFfiResultSafeKeyCb = OnFfiResultSafeKeyCb;
@@ -222,7 +222,7 @@ namespace SafeApp.AppBindings
         private static void OnFfiResultFilesContainerCb(IntPtr userData, IntPtr filesContainer)
         {
             var tcs = BindingUtils.FromHandlePtr<TaskCompletionSource<ISafeData>>(userData);
-            tcs.SetResult(Marshal.PtrToStructure<FilesContainer>(filesContainer));
+            tcs.SetResult(new FilesContainer(Marshal.PtrToStructure<FilesContainerNative>(filesContainer)));
         }
 
         private static readonly FfiResultFilesContainerCb DelegateOnFfiResultFilesContainerCb = OnFfiResultFilesContainerCb;
@@ -868,13 +868,13 @@ namespace SafeApp.AppBindings
         {
             var resolved = resolvedFrom == IntPtr.Zero ?
                 default :
-                Marshal.PtrToStructure<XorUrlEncoder>(resolvedFrom);
+                new XorUrlEncoder(Marshal.PtrToStructure<XorUrlEncoderNative>(resolvedFrom));
 
             BindingUtils.CompleteTask(
                 userData,
                 Marshal.PtrToStructure<FfiResult>(result),
                 () => (
-                    Marshal.PtrToStructure<XorUrlEncoder>(xorUrlEncoder),
+                    new XorUrlEncoder(Marshal.PtrToStructure<XorUrlEncoderNative>(xorUrlEncoder)),
                     resolved));
         }
 

--- a/SafeApp.Core/AppTypes.HighLevel.cs
+++ b/SafeApp.Core/AppTypes.HighLevel.cs
@@ -37,7 +37,6 @@ namespace SafeApp.Core
         /// <summary>
         /// XorName for the data.
         /// </summary>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)AppConstants.XorNameLen)]
         public byte[] XorName;
 
         /// <summary>
@@ -48,28 +47,68 @@ namespace SafeApp.Core
         /// <summary>
         /// Stored data type.
         /// </summary>
-        public ulong DataType;
+        public DataType DataType;
 
         /// <summary>
         /// Stored content type.
         /// </summary>
-        public ushort ContentType;
+        public ContentType ContentType;
 
         /// <summary>
         /// XorUrl path for the data.
         /// </summary>
-        [MarshalAs(UnmanagedType.LPStr)]
         public string Path;
 
         /// <summary>
         /// XorUrl sub names for the data.
         /// </summary>
-        [MarshalAs(UnmanagedType.LPStr)]
         public string SubNames;
 
         /// <summary>
         /// Content version on the network.
         /// </summary>
+        public ulong ContentVersion;
+
+        internal XorUrlEncoder(XorUrlEncoderNative native)
+        {
+            EncodingVersion = native.EncodingVersion;
+            XorName = native.XorName;
+            TypeTag = native.TypeTag;
+            DataType = (DataType)native.DataType;
+            ContentType = (ContentType)native.ContentType;
+            Path = native.Path;
+            SubNames = native.SubNames;
+            ContentVersion = native.ContentVersion;
+        }
+
+        internal XorUrlEncoderNative ToNative()
+        {
+            return new XorUrlEncoderNative
+            {
+                EncodingVersion = EncodingVersion,
+                XorName = XorName,
+                TypeTag = TypeTag,
+                DataType = (ulong)DataType,
+                ContentType = (ushort)ContentType,
+                Path = Path,
+                SubNames = SubNames,
+                ContentVersion = ContentVersion,
+            };
+        }
+    }
+
+    internal struct XorUrlEncoderNative
+    {
+        public ulong EncodingVersion;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)AppConstants.XorNameLen)]
+        public byte[] XorName;
+        public ulong TypeTag;
+        public ulong DataType;
+        public ushort ContentType;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string Path;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string SubNames;
         public ulong ContentVersion;
     }
 
@@ -89,19 +128,43 @@ namespace SafeApp.Core
         /// <summary>
         /// SafeKey's XorUrl.
         /// </summary>
-        [MarshalAs(UnmanagedType.LPStr)]
         public string XorUrl;
 
         /// <summary>
         /// SafeKey's XorName.
         /// </summary>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)AppConstants.XorNameLen)]
         public byte[] XorName;
 
         /// <summary>
         /// NrsMapContainerInfo for the SafeKey stored on the network.
         /// </summary>
         public NrsMapContainerInfo ResolvedFrom;
+
+        internal SafeKey(SafeKeyNative native)
+        {
+            XorUrl = native.XorUrl;
+            XorName = native.XorName;
+            ResolvedFrom = new NrsMapContainerInfo(native.ResolvedFrom);
+        }
+
+        internal SafeKeyNative ToNative()
+        {
+            return new SafeKeyNative
+            {
+                XorUrl = XorUrl,
+                XorName = XorName,
+                ResolvedFrom = ResolvedFrom.ToNative(),
+            };
+        }
+    }
+
+    internal struct SafeKeyNative : ISafeData
+    {
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string XorUrl;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)AppConstants.XorNameLen)]
+        public byte[] XorName;
+        public NrsMapContainerInfoNative ResolvedFrom;
     }
 
     /// <summary>
@@ -133,7 +196,7 @@ namespace SafeApp.Core
         /// <summary>
         /// Wallet data type identifier.
         /// </summary>
-        public ulong DataType;
+        public DataType DataType;
 
         /// <summary>
         /// NrsMapContainerInfo for the wallet stored on the network.
@@ -146,8 +209,8 @@ namespace SafeApp.Core
             XorName = native.XorName;
             TypeTag = native.TypeTag;
             Balances = new WalletSpendableBalances(native.Balances);
-            DataType = native.DataType;
-            ResolvedFrom = native.ResolvedFrom;
+            DataType = (DataType)native.DataType;
+            ResolvedFrom = new NrsMapContainerInfo(native.ResolvedFrom);
         }
 
         internal WalletNative ToNative()
@@ -158,8 +221,8 @@ namespace SafeApp.Core
                 XorName = XorName,
                 TypeTag = TypeTag,
                 Balances = Balances.ToNative(),
-                DataType = DataType,
-                ResolvedFrom = ResolvedFrom
+                DataType = (ulong)DataType,
+                ResolvedFrom = ResolvedFrom.ToNative(),
             };
         }
     }
@@ -173,7 +236,7 @@ namespace SafeApp.Core
         public ulong TypeTag;
         public WalletSpendableBalancesNative Balances;
         public ulong DataType;
-        public NrsMapContainerInfo ResolvedFrom;
+        public NrsMapContainerInfoNative ResolvedFrom;
 
         internal void Free()
         {
@@ -188,15 +251,13 @@ namespace SafeApp.Core
     public struct FilesContainer : ISafeData
     {
         /// <summary>
-        /// FilesContainer's XorUrl.
-        /// </summary>
-        [MarshalAs(UnmanagedType.LPStr)]
+         /// FilesContainer's XorUrl.
+         /// </summary>
         public string XorUrl;
 
         /// <summary>
         /// FilesContainer's XorName.
         /// </summary>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)AppConstants.XorNameLen)]
         public byte[] XorName;
 
         /// <summary>
@@ -212,18 +273,56 @@ namespace SafeApp.Core
         /// <summary>
         /// FilesMap in JSON format.
         /// </summary>
-        [MarshalAs(UnmanagedType.LPStr)]
         public string FilesMap;
 
         /// <summary>
         /// FilesContainer data type identifier.
         /// </summary>
-        public ulong DataType;
+        public DataType DataType;
 
         /// <summary>
         /// NrsMapContainerInfo for the FilesContainer.
         /// </summary>
         public NrsMapContainerInfo ResolvedFrom;
+
+        internal FilesContainer(FilesContainerNative native)
+        {
+            XorUrl = native.XorUrl;
+            XorName = native.XorName;
+            TypeTag = native.TypeTag;
+            Version = native.Version;
+            FilesMap = native.FilesMap;
+            DataType = (DataType)native.DataType;
+            ResolvedFrom = new NrsMapContainerInfo(native.ResolvedFrom);
+        }
+
+        internal FilesContainerNative ToNative()
+        {
+            return new FilesContainerNative
+            {
+                XorUrl = XorUrl,
+                XorName = XorName,
+                TypeTag = TypeTag,
+                Version = Version,
+                FilesMap = FilesMap,
+                DataType = (ulong)DataType,
+                ResolvedFrom = ResolvedFrom.ToNative(),
+            };
+        }
+    }
+
+    internal struct FilesContainerNative : ISafeData
+    {
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string XorUrl;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)AppConstants.XorNameLen)]
+        public byte[] XorName;
+        public ulong TypeTag;
+        public ulong Version;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string FilesMap;
+        public ulong DataType;
+        public NrsMapContainerInfoNative ResolvedFrom;
     }
 
     /// <summary>
@@ -262,7 +361,7 @@ namespace SafeApp.Core
             XorUrl = native.XorUrl;
             XorName = native.XorName;
             Data = BindingUtils.CopyToByteArray(native.DataPtr, (int)native.DataLen);
-            ResolvedFrom = native.ResolvedFrom;
+            ResolvedFrom = new NrsMapContainerInfo(native.ResolvedFrom);
             MediaType = native.MediaType;
         }
 
@@ -274,7 +373,7 @@ namespace SafeApp.Core
                 XorName = XorName,
                 DataPtr = BindingUtils.CopyFromByteArray(Data),
                 DataLen = (UIntPtr)(Data?.Length ?? 0),
-                ResolvedFrom = ResolvedFrom,
+                ResolvedFrom = ResolvedFrom.ToNative(),
                 MediaType = MediaType
             };
         }
@@ -288,7 +387,7 @@ namespace SafeApp.Core
         public byte[] XorName;
         public IntPtr DataPtr;
         public UIntPtr DataLen;
-        public NrsMapContainerInfo ResolvedFrom;
+        public NrsMapContainerInfoNative ResolvedFrom;
         [MarshalAs(UnmanagedType.LPStr)]
         public string MediaType;
 
@@ -537,19 +636,16 @@ namespace SafeApp.Core
         /// <summary>
         /// Public name for the container.
         /// </summary>
-        [MarshalAs(UnmanagedType.LPStr)]
         public string PublicName;
 
         /// <summary>
         /// Container's XorUrl.
         /// </summary>
-        [MarshalAs(UnmanagedType.LPStr)]
         public string XorUrl;
 
         /// <summary>
         /// Container's XorName.
         /// </summary>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)AppConstants.XorNameLen)]
         public byte[] XorName;
 
         /// <summary>
@@ -565,12 +661,51 @@ namespace SafeApp.Core
         /// <summary>
         /// NrsMap in JSON format.
         /// </summary>
-        [MarshalAs(UnmanagedType.LPStr)]
         public string NrsMap;
 
         /// <summary>
         /// DataType identifier for the NrsMapContainer.
         /// </summary>
+        public DataType DataType;
+
+        internal NrsMapContainerInfo(NrsMapContainerInfoNative native)
+        {
+            PublicName = native.PublicName;
+            XorUrl = native.XorUrl;
+            XorName = native.XorName;
+            TypeTag = native.TypeTag;
+            Version = native.Version;
+            NrsMap = native.NrsMap;
+            DataType = (DataType)native.DataType;
+        }
+
+        internal NrsMapContainerInfoNative ToNative()
+        {
+            return new NrsMapContainerInfoNative
+            {
+                PublicName = PublicName,
+                XorUrl = XorUrl,
+                XorName = XorName,
+                TypeTag = TypeTag,
+                Version = Version,
+                NrsMap = NrsMap,
+                DataType = (ulong)DataType,
+            };
+        }
+    }
+
+    internal struct NrsMapContainerInfoNative
+    {
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string PublicName;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string XorUrl;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)AppConstants.XorNameLen)]
+        public byte[] XorName;
+        public ulong TypeTag;
+        public ulong Version;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string NrsMap;
         public ulong DataType;
     }
 
@@ -660,6 +795,28 @@ namespace SafeApp.Core
     {
         public string SubName;
         public string SubNameRdf;
+    }
+
+    public enum DataType
+    {
+        SafeKey,
+        PublishedImmutableData,
+        UnpublishedImmutableData,
+        SeqMutableData,
+        UnseqMutableData,
+        PublishedSeqAppendOnlyData,
+        PublishedUnseqAppendOnlyData,
+        UnpublishedSeqAppendOnlyData,
+        UnpublishedUnseqAppendOnlyData,
+    }
+
+    public enum ContentType
+    {
+        Raw,
+        Wallet,
+        FilesContainer,
+        NrsMapContainer,
+        MediaType, // nb: we're missing the variant value of the rust enum here (the actual media type)
     }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/SafeApp/API/XorEncoder.cs
+++ b/SafeApp/API/XorEncoder.cs
@@ -26,8 +26,8 @@ namespace SafeApp.API
         public static Task<string> EncodeAsync(
             byte[] xorName,
             ulong typeTag,
-            ulong dataType,
-            ushort contentType,
+            DataType dataType,
+            ContentType contentType,
             string path,
             string subNames,
             ulong contentVersion,
@@ -49,8 +49,8 @@ namespace SafeApp.API
         public static Task<XorUrlEncoder> EncodeAsync(
             byte[] xorName,
             ulong typeTag,
-            ulong dataType,
-            ushort contentType,
+            DataType dataType,
+            ContentType contentType,
             string path,
             string subNames,
             ulong contentVersion)

--- a/Tests/SafeApp.Tests/FetchTest.cs
+++ b/Tests/SafeApp.Tests/FetchTest.cs
@@ -90,7 +90,7 @@ namespace SafeApp.Tests
 
         void EnsureNullNrsContainerInfo(NrsMapContainerInfo info)
         {
-            Assert.AreEqual(0, info.DataType); // iffy, since 0 is actually a data type
+            Assert.AreEqual(DataType.SafeKey, info.DataType); // iffy, since 0 is actually a data type
             Assert.IsNull(info.NrsMap);
             Assert.IsNull(info.PublicName);
             Assert.AreEqual(0, info.TypeTag); // is TT=0 used?

--- a/Tests/SafeApp.Tests/NrsTest.cs
+++ b/Tests/SafeApp.Tests/NrsTest.cs
@@ -28,9 +28,9 @@ namespace SafeApp.Tests
             var xorUrlEncoder = await Nrs.ParseUrlAsync(xorUrl);
 
             // todo: verify that these are actually the expected values
-            Assert.AreEqual(0, xorUrlEncoder.ContentType);
+            Assert.AreEqual(ContentType.Raw, xorUrlEncoder.ContentType);
             Assert.AreEqual(0, xorUrlEncoder.ContentVersion);
-            Assert.AreEqual(0, xorUrlEncoder.DataType);
+            Assert.AreEqual(DataType.SafeKey, xorUrlEncoder.DataType);
             Assert.AreEqual(1, xorUrlEncoder.EncodingVersion);
             Assert.AreEqual(string.Empty, xorUrlEncoder.Path);
             Assert.AreEqual("[]", xorUrlEncoder.SubNames);
@@ -169,19 +169,11 @@ namespace SafeApp.Tests
             ValidateEncoder(encoder, expectedContentType, expectedTypeTag);
         }
 
-        enum ContentType
-        {
-            Raw,
-            Wallet,
-            FilesContainer,
-            NrsMapContainer,
-        }
-
         void ValidateEncoder(XorUrlEncoder encoder, ContentType expectedContentType, int expectedTypeTag)
         {
-            Assert.AreEqual((ushort)expectedContentType, encoder.ContentType);
+            Assert.AreEqual(expectedContentType, encoder.ContentType);
             Assert.AreEqual(0, encoder.ContentVersion);
-            Assert.AreEqual(5, encoder.DataType);
+            Assert.AreEqual(DataType.PublishedSeqAppendOnlyData, encoder.DataType);
             Assert.AreEqual(1, encoder.EncodingVersion);
 
             // todo: these need to be validated once they contain the correct values

--- a/Tests/SafeApp.Tests/XorUrlEncoderTest.cs
+++ b/Tests/SafeApp.Tests/XorUrlEncoderTest.cs
@@ -15,12 +15,13 @@ namespace SafeApp.Tests
             Random rnd = new Random();
             var xorName = new byte[32];
             rnd.NextBytes(xorName);
-            var contenType = (ushort)1;
+            var contentType = ContentType.Wallet;
+            var dataType = DataType.UnpublishedImmutableData;
             var encodedString = await XorEncoder.EncodeAsync(
                 xorName,
                 16000,
-                2,
-                contenType,
+                dataType,
+                contentType,
                 null,
                 null,
                 0,
@@ -31,8 +32,8 @@ namespace SafeApp.Tests
             var xorEncoder = await XorEncoder.EncodeAsync(
                 xorName,
                 16000,
-                2,
-                contenType,
+                dataType,
+                contentType,
                 null,
                 null,
                 0);
@@ -46,7 +47,8 @@ namespace SafeApp.Tests
             Assert.AreEqual(xorName, encoder.XorName);
             Assert.AreNotEqual(default(XorUrlEncoder), encoder);
             Assert.AreEqual(16000, encoder.TypeTag);
-            Assert.AreEqual(contenType, encoder.ContentType);
+            Assert.AreEqual(dataType, encoder.DataType);
+            Assert.AreEqual(contentType, encoder.ContentType);
             Assert.AreEqual(0, encoder.ContentVersion);
         }
     }


### PR DESCRIPTION
This will replace `ulong` and `ushort` representation of the content type and data type, with enum.
Additional structs have been added to `AppTypes.HighLevel.cs`. Seems a little bit "bloaty" to duplicate all those properties just for a single prop type change, but perhaps not many simple options there now.

NB: `ContentType.MediaType` is also conveying media type natively, but we're currently not capturing that value.

Fixes: #133 