### PR TITLE
refactor/tests: clean up tests

### DIFF
--- a/Tests/SafeApp.Tests/FetchTest.cs
+++ b/Tests/SafeApp.Tests/FetchTest.cs
@@ -44,24 +44,24 @@ namespace SafeApp.Tests
                 switch (data)
                 {
                     case SafeKey key:
-                        TestUtils.ValidateXorName(key.XorName);
-                        EnsureNullNrsContainerInfo(key.ResolvedFrom);
+                        Validate.XorName(key.XorName);
+                        Validate.EnsureNullNrsContainerInfo(key.ResolvedFrom);
                         break;
                     case Wallet wallet:
-                        TestUtils.ValidateXorName(wallet.XorName);
-                        EnsureNullNrsContainerInfo(wallet.ResolvedFrom);
+                        Validate.XorName(wallet.XorName);
+                        Validate.EnsureNullNrsContainerInfo(wallet.ResolvedFrom);
                         break;
                     case FilesContainer filesContainer:
-                        TestUtils.ValidateXorName(filesContainer.XorName);
+                        Validate.XorName(filesContainer.XorName);
                         if (expectNrs)
-                            ValidateNrsContainerInfo(filesContainer.ResolvedFrom);
+                            Validate.NrsContainerInfo(filesContainer.ResolvedFrom);
                         else
-                            EnsureNullNrsContainerInfo(filesContainer.ResolvedFrom);
+                            Validate.EnsureNullNrsContainerInfo(filesContainer.ResolvedFrom);
                         break;
                     case PublishedImmutableData immutableData:
                         Assert.IsNotNull(immutableData.Data);
-                        TestUtils.ValidateXorName(immutableData.XorName);
-                        ValidateNrsContainerInfo(immutableData.ResolvedFrom);
+                        Validate.XorName(immutableData.XorName);
+                        Validate.NrsContainerInfo(immutableData.ResolvedFrom);
                         break;
                     case SafeDataFetchFailed dataFetchFailed:
                         Assert.IsNotNull(dataFetchFailed.Description);
@@ -75,28 +75,6 @@ namespace SafeApp.Tests
             {
                 Assert.Fail("Fetch data type not available");
             }
-        }
-
-        void ValidateNrsContainerInfo(NrsMapContainerInfo info)
-        {
-            Assert.AreNotEqual(0, info.DataType);
-            Assert.IsNotNull(info.NrsMap);
-            Assert.IsNotNull(info.PublicName);
-            Assert.AreNotEqual(0, info.TypeTag);
-            Assert.IsNotNull(info.Version);
-            Assert.IsNotNull(info.XorUrl);
-            TestUtils.ValidateXorName(info.XorName);
-        }
-
-        void EnsureNullNrsContainerInfo(NrsMapContainerInfo info)
-        {
-            Assert.AreEqual(DataType.SafeKey, info.DataType); // iffy, since 0 is actually a data type
-            Assert.IsNull(info.NrsMap);
-            Assert.IsNull(info.PublicName);
-            Assert.AreEqual(0, info.TypeTag); // is TT=0 used?
-            Assert.AreEqual(0, info.Version); // iffy, since v 0 is actually the first version
-            Assert.IsNull(info.XorUrl);
-            Assert.IsTrue(Enumerable.SequenceEqual(new byte[32], info.XorName));
         }
     }
 }

--- a/Tests/SafeApp.Tests/KeyTest.cs
+++ b/Tests/SafeApp.Tests/KeyTest.cs
@@ -6,133 +6,121 @@ namespace SafeApp.Tests
     [TestFixture]
     internal class KeyTest
     {
+        private const string _preloadInitialAmount = "2";
+        private const string _transferAmount = "1";
+        private const string _preloadAmount = "1";
+        private API.Keys _api;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            var session = await TestUtils.CreateTestApp();
+            _api = session.Keys;
+        }
+
         [Test]
         public async Task GenerateKeyPairTest()
         {
-            var session = await TestUtils.CreateTestApp();
-            var api = session.Keys;
-            var keyPair = await api.GenerateKeyPairAsync();
+            var keyPair = await _api.GenerateKeyPairAsync();
             Validate.TransientKeyPair(keyPair);
         }
 
         [Test]
         public async Task KeysCreatePreloadTestCoinsTest()
         {
-            var session = await TestUtils.CreateTestApp();
-            var api = session.Keys;
-            var (xorUrl, keyPair) = await api.KeysCreatePreloadTestCoinsAsync("1");
-            await Validate.PersistedKeyPair(xorUrl, keyPair, api);
+            var (xorUrl, keyPair) = await _api.KeysCreatePreloadTestCoinsAsync(_preloadAmount);
+            await Validate.PersistedKeyPair(xorUrl, keyPair, _api);
         }
 
         [Test]
         public async Task CreateKeysFromTransientTest()
         {
-            var session = await TestUtils.CreateTestApp();
-            var api = session.Keys;
-            var initialAmount = "2";
-            var transferAmount = "1";
-            var (_, keyPairSender) = await api.KeysCreatePreloadTestCoinsAsync(initialAmount);
+            var (_, keyPairSender) = await _api.KeysCreatePreloadTestCoinsAsync(_preloadInitialAmount);
 
             // transient keys, not persisted on the network
-            var keyPairRecipient = await api.GenerateKeyPairAsync();
+            var keyPairRecipient = await _api.GenerateKeyPairAsync();
 
             // we expect keyPairRecipient to persisted with
             // this call, and newKeyPair to be empty.
-            var (xorUrl, newKeyPair) = await api.CreateKeysAsync(
+            var (xorUrl, newKeyPair) = await _api.CreateKeysAsync(
                 keyPairSender.SK,
-                transferAmount,
+                _transferAmount,
                 keyPairRecipient.PK);
 
             Assert.IsNull(newKeyPair.PK);
             Assert.IsNull(newKeyPair.SK);
 
-            await Validate.PersistedKeyPair(xorUrl, keyPairRecipient, api);
+            await Validate.PersistedKeyPair(xorUrl, keyPairRecipient, _api);
 
-            var senderBalance = await api.KeysBalanceFromSkAsync(newKeyPair.SK);
-            Validate.IsEqualAmount(transferAmount, senderBalance);
+            var senderBalance = await _api.KeysBalanceFromSkAsync(newKeyPair.SK);
+            Validate.IsEqualAmount(_transferAmount, senderBalance);
 
-            var recipientBalance = await api.KeysBalanceFromSkAsync(newKeyPair.SK);
-            Validate.IsEqualAmount(transferAmount, recipientBalance);
+            var recipientBalance = await _api.KeysBalanceFromSkAsync(newKeyPair.SK);
+            Validate.IsEqualAmount(_transferAmount, recipientBalance);
         }
 
         [Test]
         public async Task CreateKeysTest()
         {
-            var session = await TestUtils.CreateTestApp();
-            var api = session.Keys;
-            var initialAmount = "2";
-            var transferAmount = "1";
-            var (_, keyPairSender) = await api.KeysCreatePreloadTestCoinsAsync(initialAmount);
+            var (_, keyPairSender) = await _api.KeysCreatePreloadTestCoinsAsync(_preloadInitialAmount);
 
-            var (xorUrl, newKeyPair) = await api.CreateKeysAsync(
+            var (xorUrl, newKeyPair) = await _api.CreateKeysAsync(
                 keyPairSender.SK,
-                transferAmount,
+                _transferAmount,
                 null);
 
-            await Validate.PersistedKeyPair(xorUrl, newKeyPair, api);
+            await Validate.PersistedKeyPair(xorUrl, newKeyPair, _api);
 
-            var senderBalance = await api.KeysBalanceFromSkAsync(newKeyPair.SK);
-            Validate.IsEqualAmount(transferAmount, senderBalance);
+            var senderBalance = await _api.KeysBalanceFromSkAsync(newKeyPair.SK);
+            Validate.IsEqualAmount(_transferAmount, senderBalance);
 
-            var recipientBalance = await api.KeysBalanceFromSkAsync(newKeyPair.SK);
-            Validate.IsEqualAmount(transferAmount, recipientBalance);
+            var recipientBalance = await _api.KeysBalanceFromSkAsync(newKeyPair.SK);
+            Validate.IsEqualAmount(_transferAmount, recipientBalance);
         }
 
         [Test]
         public async Task KeysBalanceFromSkTest()
         {
-            var session = await TestUtils.CreateTestApp();
-            var api = session.Keys;
-            var amount = "1";
-            var (xorurl, keyPair) = await api.KeysCreatePreloadTestCoinsAsync(amount);
-            var balance = await api.KeysBalanceFromSkAsync(keyPair.SK);
-            Validate.IsEqualAmount(amount, balance);
+            var (xorurl, keyPair) = await _api.KeysCreatePreloadTestCoinsAsync(_preloadAmount);
+            var balance = await _api.KeysBalanceFromSkAsync(keyPair.SK);
+            Validate.IsEqualAmount(_preloadAmount, balance);
         }
 
         [Test]
         public async Task KeysBalanceFromUrlTest()
         {
-            var session = await TestUtils.CreateTestApp();
-            var api = session.Keys;
-            var amount = "1";
-            var (xorurl, keyPair) = await api.KeysCreatePreloadTestCoinsAsync(amount);
-            var balance = await api.KeysBalanceFromUrlAsync(xorurl, keyPair.SK);
-            Validate.IsEqualAmount(amount, balance);
+            var (xorurl, keyPair) = await _api.KeysCreatePreloadTestCoinsAsync(_preloadAmount);
+            var balance = await _api.KeysBalanceFromUrlAsync(xorurl, keyPair.SK);
+            Validate.IsEqualAmount(_preloadAmount, balance);
         }
 
         [Test]
         public async Task ValidateSkForUrlTest()
         {
-            var session = await TestUtils.CreateTestApp();
-            var api = session.Keys;
-            var (xorurl, keyPair) = await api.KeysCreatePreloadTestCoinsAsync("1");
-            var publicKey = await api.ValidateSkForUrlAsync(keyPair.SK, xorurl);
+            var (xorurl, keyPair) = await _api.KeysCreatePreloadTestCoinsAsync(_preloadAmount);
+            var publicKey = await _api.ValidateSkForUrlAsync(keyPair.SK, xorurl);
             Assert.AreEqual(keyPair.PK, publicKey);
         }
 
         [Test]
         public async Task KeysTransferTest()
         {
-            var amountToSend = "1";
             var initialRecipientBalance = "0.1";
             var expectedRecipientEndBalance = "1.1";
             var expectedSenderEndBalance = "0";
 
             var txId = 1234UL;
 
-            var session = await TestUtils.CreateTestApp();
-            var api = session.Keys;
-
-            var (senderUrl, keyPairSender) = await api.KeysCreatePreloadTestCoinsAsync(amountToSend);
-            var (recipientUrl, keyPairRecipient) = await api.KeysCreatePreloadTestCoinsAsync(initialRecipientBalance);
-            var resultTxId = await api.KeysTransferAsync(amountToSend, keyPairSender.SK, recipientUrl, txId);
+            var (senderUrl, keyPairSender) = await _api.KeysCreatePreloadTestCoinsAsync(_transferAmount);
+            var (recipientUrl, keyPairRecipient) = await _api.KeysCreatePreloadTestCoinsAsync(initialRecipientBalance);
+            var resultTxId = await _api.KeysTransferAsync(_transferAmount, keyPairSender.SK, recipientUrl, txId);
 
             Assert.AreEqual(txId, resultTxId);
 
-            var senderBalance = await api.KeysBalanceFromUrlAsync(senderUrl, keyPairSender.SK);
+            var senderBalance = await _api.KeysBalanceFromUrlAsync(senderUrl, keyPairSender.SK);
             Validate.IsEqualAmount(expectedSenderEndBalance, senderBalance);
 
-            var recipientBalance = await api.KeysBalanceFromUrlAsync(recipientUrl, keyPairRecipient.SK);
+            var recipientBalance = await _api.KeysBalanceFromUrlAsync(recipientUrl, keyPairRecipient.SK);
             Validate.IsEqualAmount(expectedRecipientEndBalance, recipientBalance);
         }
     }

--- a/Tests/SafeApp.Tests/KeyTest.cs
+++ b/Tests/SafeApp.Tests/KeyTest.cs
@@ -11,7 +11,7 @@ namespace SafeApp.Tests
         private const string _preloadAmount = "1";
         private API.Keys _api;
 
-        [OneTimeSetUp]
+        [SetUp]
         public async Task Setup()
         {
             var session = await TestUtils.CreateTestApp();

--- a/Tests/SafeApp.Tests/SafeApp.Tests.projitems
+++ b/Tests/SafeApp.Tests/SafeApp.Tests.projitems
@@ -14,9 +14,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)AuthTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MiscTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestUtils.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Validations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XorUrlEncoderTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WalletTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FilesTest.cs" />
-	<Compile Include="$(MSBuildThisFileDirectory)NrsTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NrsTest.cs" />
   </ItemGroup>
 </Project>

--- a/Tests/SafeApp.Tests/TestUtils.cs
+++ b/Tests/SafeApp.Tests/TestUtils.cs
@@ -85,13 +85,6 @@ namespace SafeApp.Tests
             return new string(Enumerable.Repeat(chars, length).Select(s => s[Random.Next(s.Length)]).ToArray());
         }
 
-        public static void ValidateXorName(byte[] xorName)
-        {
-            Assert.IsNotNull(xorName);
-            Assert.AreEqual(32, xorName.Length);
-            Assert.IsFalse(Enumerable.SequenceEqual(new byte[32], xorName));
-        }
-
         public static void PrepareTestData()
         {
             System.IO.Directory.CreateDirectory(TestDataDir);

--- a/Tests/SafeApp.Tests/Validations.cs
+++ b/Tests/SafeApp.Tests/Validations.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SafeApp.API;
+using SafeApp.Core;
+
+namespace SafeApp.Tests
+{
+    class Validate
+    {
+        public static void XorName(byte[] xorName)
+        {
+            Assert.IsNotNull(xorName);
+            Assert.AreEqual(32, xorName.Length);
+            Assert.IsFalse(Enumerable.SequenceEqual(new byte[32], xorName));
+        }
+
+        public static void NrsContainerInfo(NrsMapContainerInfo info)
+        {
+            Assert.AreNotEqual(0, info.DataType);
+            Assert.IsNotNull(info.NrsMap);
+            Assert.IsNotNull(info.PublicName);
+            Assert.AreNotEqual(0, info.TypeTag);
+            Assert.IsNotNull(info.Version);
+            Assert.IsNotNull(info.XorUrl);
+            Validate.XorName(info.XorName);
+        }
+
+        public static void EnsureNullNrsContainerInfo(NrsMapContainerInfo info)
+        {
+            Assert.AreEqual(DataType.SafeKey, info.DataType); // iffy, since 0 is actually a data type
+            Assert.IsNull(info.NrsMap);
+            Assert.IsNull(info.PublicName);
+            Assert.AreEqual(0, info.TypeTag); // is TT=0 used?
+            Assert.AreEqual(0, info.Version); // iffy, since v 0 is actually the first version
+            Assert.IsNull(info.XorUrl);
+            Assert.IsTrue(Enumerable.SequenceEqual(new byte[32], info.XorName));
+        }
+
+        public static async Task XorUrlAsync(string xorUrl, DataType expectedDataType, ContentType expectedContentType, ulong expectedTypeTag)
+        {
+            var encoder = await XorEncoder.XorUrlEncoderFromUrl(xorUrl);
+            Encoder(encoder, expectedDataType, expectedContentType, expectedTypeTag);
+        }
+
+        public static void Encoder(XorUrlEncoder encoder, DataType expectedDataType, ContentType expectedContentType, ulong expectedTypeTag)
+        {
+            Assert.AreEqual(expectedContentType, encoder.ContentType);
+            Assert.AreEqual(0, encoder.ContentVersion);
+            Assert.AreEqual(expectedDataType, encoder.DataType);
+            Assert.AreEqual(1, encoder.EncodingVersion);
+
+            // todo: these need to be validated once they contain the correct values
+
+            /**
+            Assert.AreEqual(string.Empty, encoder.Path);
+            Assert.AreEqual(string.Empty, encoder.SubNames);
+            **/
+            Assert.AreEqual(expectedTypeTag, encoder.TypeTag);
+            Validate.XorName(encoder.XorName);
+        }
+
+        public static async Task RawNrsMapAsync(string nrsMapRaw)
+        {
+            Assert.IsNotNull(nrsMapRaw);
+            var nrsMap = Serialization.Deserialize<NrsMap>(nrsMapRaw);
+
+            Assert.IsNull(nrsMap.SubNamesMap);
+            /**
+            foreach (var entry in nrsMap.SubNamesMap.Values)
+            {
+                Assert.IsNotNull(entry.SubName);
+                Assert.IsNotNull(entry.SubNameRdf);
+            }
+            **/
+            Assert.IsNotNull(nrsMap.Default);
+            Assert.AreEqual(1, nrsMap.Default.Count);
+            foreach (var rdf in nrsMap.Default.Values)
+            {
+                Assert.AreNotEqual(default(DateTime), rdf.Created);
+                Assert.AreNotEqual(default(DateTime), rdf.Modified);
+                Assert.IsNotNull(rdf.Link);
+                await Validate.XorUrlAsync(rdf.Link, DataType.PublishedSeqAppendOnlyData, ContentType.FilesContainer, 1100);
+            }
+        }
+
+        public static void TransientKeyPair(BlsKeyPair keyPair)
+        {
+            Assert.IsNotNull(keyPair.PK);
+            Assert.IsNotNull(keyPair.SK);
+            Assert.AreNotSame(string.Empty, keyPair.PK);
+            Assert.AreNotSame(string.Empty, keyPair.SK);
+            Assert.AreNotSame(keyPair.PK, keyPair.SK);
+        }
+
+        public static async Task PersistedKeyPair(string xorUrl, BlsKeyPair keyPair, Keys api)
+        {
+            Validate.TransientKeyPair(keyPair);
+            await Validate.XorUrlAsync(xorUrl, 0, ContentType.Raw, 0);
+            var publicKey = await api.ValidateSkForUrlAsync(keyPair.SK, xorUrl);
+            Assert.AreEqual(keyPair.PK, publicKey);
+        }
+
+        public static void IsEqualAmount(string expected, string actual)
+        {
+            Assert.AreEqual(
+                decimal.Parse(expected, CultureInfo.InvariantCulture),
+                decimal.Parse(actual, CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/Tests/SafeApp.Tests/Validations.cs
+++ b/Tests/SafeApp.Tests/Validations.cs
@@ -19,10 +19,10 @@ namespace SafeApp.Tests
 
         public static void NrsContainerInfo(NrsMapContainerInfo info)
         {
-            Assert.AreNotEqual(0, info.DataType);
+            Assert.AreNotEqual(DataType.SafeKey, info.DataType);
             Assert.IsNotNull(info.NrsMap);
             Assert.IsNotNull(info.PublicName);
-            Assert.AreNotEqual(0, info.TypeTag);
+            Assert.NotZero(info.TypeTag);
             Assert.IsNotNull(info.Version);
             Assert.IsNotNull(info.XorUrl);
             Validate.XorName(info.XorName);
@@ -30,11 +30,11 @@ namespace SafeApp.Tests
 
         public static void EnsureNullNrsContainerInfo(NrsMapContainerInfo info)
         {
-            Assert.AreEqual(DataType.SafeKey, info.DataType); // iffy, since 0 is actually a data type
+            Assert.AreEqual(DataType.SafeKey, info.DataType); // since 0 is actually a data type
             Assert.IsNull(info.NrsMap);
             Assert.IsNull(info.PublicName);
-            Assert.AreEqual(0, info.TypeTag); // is TT=0 used?
-            Assert.AreEqual(0, info.Version); // iffy, since v 0 is actually the first version
+            Assert.Zero(info.TypeTag);
+            Assert.Zero(info.Version); // since v 0 is actually the first version
             Assert.IsNull(info.XorUrl);
             Assert.IsTrue(Enumerable.SequenceEqual(new byte[32], info.XorName));
         }
@@ -48,7 +48,7 @@ namespace SafeApp.Tests
         public static void Encoder(XorUrlEncoder encoder, DataType expectedDataType, ContentType expectedContentType, ulong expectedTypeTag)
         {
             Assert.AreEqual(expectedContentType, encoder.ContentType);
-            Assert.AreEqual(0, encoder.ContentVersion);
+            Assert.Zero(encoder.ContentVersion);
             Assert.AreEqual(expectedDataType, encoder.DataType);
             Assert.AreEqual(1, encoder.EncodingVersion);
 
@@ -90,15 +90,15 @@ namespace SafeApp.Tests
         {
             Assert.IsNotNull(keyPair.PK);
             Assert.IsNotNull(keyPair.SK);
-            Assert.AreNotSame(string.Empty, keyPair.PK);
-            Assert.AreNotSame(string.Empty, keyPair.SK);
+            Assert.IsNotEmpty(keyPair.PK);
+            Assert.IsNotEmpty(keyPair.SK);
             Assert.AreNotSame(keyPair.PK, keyPair.SK);
         }
 
         public static async Task PersistedKeyPair(string xorUrl, BlsKeyPair keyPair, Keys api)
         {
             Validate.TransientKeyPair(keyPair);
-            await Validate.XorUrlAsync(xorUrl, 0, ContentType.Raw, 0);
+            await Validate.XorUrlAsync(xorUrl, DataType.SafeKey, ContentType.Raw, 0);
             var publicKey = await api.ValidateSkForUrlAsync(keyPair.SK, xorUrl);
             Assert.AreEqual(keyPair.PK, publicKey);
         }

--- a/Tests/SafeApp.Tests/WalletTests.cs
+++ b/Tests/SafeApp.Tests/WalletTests.cs
@@ -7,13 +7,13 @@ namespace SafeApp.Tests
     [TestFixture]
     internal class WalletTest
     {
-        private const string NAME1 = "TestBalance1";
-        private const string NAME2 = "TestBalance2";
+        private string _testWalletOne = TestUtils.GetRandomString(10);
+        private string _testWalletTwo = TestUtils.GetRandomString(10);
 
         [Test]
         public async Task CreateWalletTest()
         {
-            var (_, api, _) = await GetAPIsAsync();
+            var (api, _) = await GetKeysAndWalletAPIs();
 
             var wallet = await api.WalletCreateAsync();
             var balance = await api.WalletBalanceAsync(wallet);
@@ -23,7 +23,7 @@ namespace SafeApp.Tests
         [Test]
         public async Task InsertAndBalanceTest()
         {
-            var (_, api, keysApi) = await GetAPIsAsync();
+            var (api, keysApi) = await GetKeysAndWalletAPIs();
 
             var walletXorUrl = await api.WalletCreateAsync();
             var keyPair_1_Balance = "123";
@@ -31,12 +31,12 @@ namespace SafeApp.Tests
             var expectedEndBalance = "444";
             var (_, keyPair1) = await keysApi.KeysCreatePreloadTestCoinsAsync(keyPair_1_Balance);
             var (_, keyPair2) = await keysApi.KeysCreatePreloadTestCoinsAsync(keyPair_2_Balance);
-            await api.WalletInsertAsync(walletXorUrl, NAME1, setDefault: true, keyPair1.SK);
+            await api.WalletInsertAsync(walletXorUrl, _testWalletOne, setDefault: true, keyPair1.SK);
 
             var currentBalance = await api.WalletBalanceAsync(walletXorUrl);
             Validate.IsEqualAmount(keyPair_1_Balance, currentBalance);
 
-            await api.WalletInsertAsync(walletXorUrl, "TestBalance2", setDefault: false, keyPair2.SK);
+            await api.WalletInsertAsync(walletXorUrl, _testWalletTwo, setDefault: false, keyPair2.SK);
             currentBalance = await api.WalletBalanceAsync(walletXorUrl);
             Validate.IsEqualAmount(expectedEndBalance, currentBalance);
         }
@@ -44,54 +44,54 @@ namespace SafeApp.Tests
         [Test]
         public async Task InsertAndGetTest()
         {
-            var (session, api, keysApi) = await GetAPIsAsync();
+            var (api, keysApi) = await GetKeysAndWalletAPIs();
 
             var walletXorUrl = await api.WalletCreateAsync();
             var (xorUrl1, keyPair1) = await keysApi.KeysCreatePreloadTestCoinsAsync("123");
             var (xorUrl2, keyPair2) = await keysApi.KeysCreatePreloadTestCoinsAsync("321");
 
-            await api.WalletInsertAsync(walletXorUrl, NAME1, setDefault: true, keyPair1.SK);
-            await api.WalletInsertAsync(walletXorUrl, NAME2, setDefault: false, keyPair2.SK);
+            await api.WalletInsertAsync(walletXorUrl, _testWalletOne, setDefault: true, keyPair1.SK);
+            await api.WalletInsertAsync(walletXorUrl, _testWalletTwo, setDefault: false, keyPair2.SK);
 
             var walletBalances = await api.WalletGetAsync(walletXorUrl);
-            Assert.IsTrue(walletBalances.WalletBalances.Find(q => q.WalletName.Equals(NAME1)).IsDefault);
-            Assert.AreEqual(Find(walletBalances, NAME1).XorUrl, xorUrl1);
-            Assert.AreEqual(Find(walletBalances, NAME1).Sk, keyPair1.SK);
+            Assert.IsTrue(walletBalances.WalletBalances.Find(q => q.WalletName.Equals(_testWalletOne)).IsDefault);
+            Assert.AreEqual(FindWalletBalance(walletBalances, _testWalletOne).XorUrl, xorUrl1);
+            Assert.AreEqual(FindWalletBalance(walletBalances, _testWalletOne).Sk, keyPair1.SK);
 
-            Assert.IsFalse(walletBalances.WalletBalances.Find(q => q.WalletName.Equals(NAME2)).IsDefault);
-            Assert.AreEqual(Find(walletBalances, NAME2).XorUrl, xorUrl2);
-            Assert.AreEqual(Find(walletBalances, NAME2).Sk, keyPair2.SK);
+            Assert.IsFalse(walletBalances.WalletBalances.Find(q => q.WalletName.Equals(_testWalletTwo)).IsDefault);
+            Assert.AreEqual(FindWalletBalance(walletBalances, _testWalletTwo).XorUrl, xorUrl2);
+            Assert.AreEqual(FindWalletBalance(walletBalances, _testWalletTwo).Sk, keyPair2.SK);
         }
 
         [Test]
         public async Task WalletInsertAndSetDefaultTest()
         {
-            var (session, api, keysApi) = await GetAPIsAsync();
+            var (api, keysApi) = await GetKeysAndWalletAPIs();
 
             var walletXorUrl = await api.WalletCreateAsync();
             var (xorUrl1, keyPair1) = await keysApi.KeysCreatePreloadTestCoinsAsync("123");
             var (xorUrl2, keyPair2) = await keysApi.KeysCreatePreloadTestCoinsAsync("321");
 
-            await api.WalletInsertAsync(walletXorUrl, NAME1, setDefault: true, keyPair1.SK);
-            await api.WalletInsertAsync(walletXorUrl, NAME2, setDefault: true, keyPair2.SK);
+            await api.WalletInsertAsync(walletXorUrl, _testWalletOne, setDefault: true, keyPair1.SK);
+            await api.WalletInsertAsync(walletXorUrl, _testWalletTwo, setDefault: true, keyPair2.SK);
             var walletBalances = await api.WalletGetAsync(walletXorUrl);
 
-            Assert.IsFalse(walletBalances.WalletBalances.Find(q => q.WalletName.Equals(NAME1)).IsDefault);
-            Assert.AreEqual(Find(walletBalances, NAME1).XorUrl, xorUrl1);
-            Assert.AreEqual(Find(walletBalances, NAME1).Sk, keyPair1.SK);
+            Assert.IsFalse(walletBalances.WalletBalances.Find(q => q.WalletName.Equals(_testWalletOne)).IsDefault);
+            Assert.AreEqual(FindWalletBalance(walletBalances, _testWalletOne).XorUrl, xorUrl1);
+            Assert.AreEqual(FindWalletBalance(walletBalances, _testWalletOne).Sk, keyPair1.SK);
 
-            Assert.IsTrue(walletBalances.WalletBalances.Find(q => q.WalletName.Equals(NAME2)).IsDefault);
-            Assert.AreEqual(Find(walletBalances, NAME2).XorUrl, xorUrl2);
-            Assert.AreEqual(Find(walletBalances, NAME2).Sk, keyPair2.SK);
+            Assert.IsTrue(walletBalances.WalletBalances.Find(q => q.WalletName.Equals(_testWalletTwo)).IsDefault);
+            Assert.AreEqual(FindWalletBalance(walletBalances, _testWalletTwo).XorUrl, xorUrl2);
+            Assert.AreEqual(FindWalletBalance(walletBalances, _testWalletTwo).Sk, keyPair2.SK);
         }
 
-        WalletSpendableBalance Find(WalletSpendableBalances list, string name)
+        WalletSpendableBalance FindWalletBalance(WalletSpendableBalances list, string name)
             => list.WalletBalances.Find(q => q.WalletName.Equals(name)).Balance;
 
         [Test]
         public async Task TransferWithoutDefaultBalanceTest()
         {
-            var (session, api, keysApi) = await GetAPIsAsync();
+            var (api, keysApi) = await GetKeysAndWalletAPIs();
 
             // without default balance
             var fromWalletXorUrl = await api.WalletCreateAsync();
@@ -108,7 +108,7 @@ namespace SafeApp.Tests
         [Test]
         public async Task TransferFromZeroBalanceTest()
         {
-            var (session, api, keysApi) = await GetAPIsAsync();
+            var (api, keysApi) = await GetKeysAndWalletAPIs();
 
             var fromWalletXorUrl = await api.WalletCreateAsync();
             var (_, keyPair1) = await keysApi.KeysCreatePreloadTestCoinsAsync("0.0");
@@ -128,11 +128,11 @@ namespace SafeApp.Tests
         [Test]
         public async Task TransferDifferentAmountsTest()
         {
-            var (session, api, keysApi) = await GetAPIsAsync();
+            var (api, keysApi) = await GetKeysAndWalletAPIs();
 
             var fromWalletXorUrl = await api.WalletCreateAsync();
             var (_, keyPair1) = await keysApi.KeysCreatePreloadTestCoinsAsync("123.321");
-            await api.WalletInsertAsync(fromWalletXorUrl, NAME1, setDefault: true, keyPair1.SK);
+            await api.WalletInsertAsync(fromWalletXorUrl, _testWalletOne, setDefault: true, keyPair1.SK);
 
             var (toXorUrl, keypair2) = await keysApi.KeysCreatePreloadTestCoinsAsync("0.5");
             await api.WalletInsertAsync(fromWalletXorUrl, "TestBalance2", setDefault: false, keypair2.SK);
@@ -150,7 +150,7 @@ namespace SafeApp.Tests
         [Test]
         public async Task TransferToSafeKeyTest()
         {
-            var (_, api, keysApi) = await GetAPIsAsync();
+            var (api, keysApi) = await GetKeysAndWalletAPIs();
 
             var fromWalletXorUrl = await api.WalletCreateAsync();
             var (_, keyPair1) = await keysApi.KeysCreatePreloadTestCoinsAsync("123.321");
@@ -165,7 +165,7 @@ namespace SafeApp.Tests
         [Test]
         public async Task TransferFromSafeKeyTest()
         {
-            var (session, api, keysApi) = await GetAPIsAsync();
+            var (api, keysApi) = await GetKeysAndWalletAPIs();
 
             var (safekeyXorUrl1, _) = await keysApi.KeysCreatePreloadTestCoinsAsync("10");
             var (safekeyXorUrl2, _) = await keysApi.KeysCreatePreloadTestCoinsAsync("0");
@@ -176,22 +176,22 @@ namespace SafeApp.Tests
         [Test]
         public async Task TransferFromUnownedWalletTest()
         {
-            var (_, api1, keysApi1) = await GetAPIsAsync();
+            var (api1, keysApi1) = await GetKeysAndWalletAPIs();
 
             var account1WalletXORURL = await api1.WalletCreateAsync();
             var (keyXorUrl1, keyPair1) = await keysApi1.KeysCreatePreloadTestCoinsAsync("123.321");
             await api1.WalletInsertAsync(account1WalletXORURL, "TestBalance", setDefault: true, keyPair1.SK);
 
-            var (_, api2, keysApi2) = await GetAPIsAsync();
+            var (api2, keysApi2) = await GetKeysAndWalletAPIs();
             var (keyXorUrl, keyPair2) = await keysApi2.KeysCreatePreloadTestCoinsAsync("123.321");
 
             AssertThrows(-102, () => api2.WalletTransferAsync(account1WalletXORURL, keyXorUrl, "5", 0));
         }
 
-        async Task<(Session, API.Wallet, API.Keys)> GetAPIsAsync()
+        async Task<(API.Wallet, API.Keys)> GetKeysAndWalletAPIs()
         {
             var session = await TestUtils.CreateTestApp();
-            return (session, session.Wallet, session.Keys);
+            return (session.Wallet, session.Keys);
         }
 
         void AssertThrows(int errorCode, AsyncTestDelegate func)

--- a/Tests/SafeApp.Tests/XorUrlEncoderTest.cs
+++ b/Tests/SafeApp.Tests/XorUrlEncoderTest.cs
@@ -12,14 +12,15 @@ namespace SafeApp.Tests
         [Test]
         public async Task EncodeStringTestAsync()
         {
-            Random rnd = new Random();
+            var rnd = new Random();
             var xorName = new byte[32];
             rnd.NextBytes(xorName);
+            var typeTag = 16000UL;
             var contentType = ContentType.Wallet;
             var dataType = DataType.UnpublishedImmutableData;
             var encodedString = await XorEncoder.EncodeAsync(
                 xorName,
-                16000,
+                typeTag,
                 dataType,
                 contentType,
                 null,
@@ -29,27 +30,25 @@ namespace SafeApp.Tests
             Assert.IsNotNull(encodedString);
             Assert.IsTrue(encodedString.StartsWith("safe://", StringComparison.Ordinal));
 
-            var xorEncoder = await XorEncoder.EncodeAsync(
+            var xorUrlEncoder = await XorEncoder.EncodeAsync(
                 xorName,
-                16000,
+                typeTag,
                 dataType,
                 contentType,
                 null,
                 null,
                 0);
 
-            Assert.AreEqual(xorName, xorEncoder.XorName);
-            Assert.AreNotEqual(default(XorUrlEncoder), xorEncoder);
-            Assert.AreNotEqual(0, xorEncoder.TypeTag);
+            Assert.AreEqual(xorName, xorUrlEncoder.XorName);
+            Validate.Encoder(xorUrlEncoder, dataType, (ContentType)contentType, typeTag);
 
-            var encoder = await XorEncoder.XorUrlEncoderFromUrl(encodedString);
+            var parsedEncoder = await XorEncoder.XorUrlEncoderFromUrl(encodedString);
 
-            Assert.AreEqual(xorName, encoder.XorName);
-            Assert.AreNotEqual(default(XorUrlEncoder), encoder);
-            Assert.AreEqual(16000, encoder.TypeTag);
-            Assert.AreEqual(dataType, encoder.DataType);
-            Assert.AreEqual(contentType, encoder.ContentType);
-            Assert.AreEqual(0, encoder.ContentVersion);
+            Assert.AreEqual(xorName, parsedEncoder.XorName);
+            Validate.Encoder(parsedEncoder, dataType, contentType, typeTag);
+            Assert.AreEqual(typeTag, parsedEncoder.TypeTag);
+            Assert.AreEqual(contentType, parsedEncoder.ContentType);
+            Assert.AreEqual(0, parsedEncoder.ContentVersion);
         }
     }
 }


### PR DESCRIPTION
Validations can be re-used between tests. Additionally, there is a lot of duplicate and excess code for various parts of the tests, which is cleaned up and made more space efficient, readable and terse with this commit.
Fixes: #125