### PR TITLE
add set_config_dir_path and logger tests

### DIFF
--- a/Build/NativeScriptDownloader.cake
+++ b/Build/NativeScriptDownloader.cake
@@ -1,4 +1,4 @@
-var TAG = "af42208";
+var TAG = "7be1a21";
 
 var S3_DOWNLOAD_BASE_URL = "https://safe-cli.s3.amazonaws.com/";
 var LIB_DIR_NAME = "../SafeApp.AppBindings/NativeLibs/";

--- a/Build/NativeScriptDownloader.cake
+++ b/Build/NativeScriptDownloader.cake
@@ -1,4 +1,4 @@
-var TAG = "7be1a21";
+var TAG = "8a3c183";
 
 var S3_DOWNLOAD_BASE_URL = "https://safe-cli.s3.amazonaws.com/";
 var LIB_DIR_NAME = "../SafeApp.AppBindings/NativeLibs/";

--- a/Tests/SafeApp.Tests.Core/SafeApp.Tests.Core.csproj
+++ b/Tests/SafeApp.Tests.Core/SafeApp.Tests.Core.csproj
@@ -14,6 +14,10 @@
     <DefineConstants>TRACE;DEBUG;__DESKTOP__</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
+    <DefineConstants>TRACE;DEBUG;__DESKTOP__;WIN64</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\libsafe_api.dylib" Link="libsafe_api.dylib" Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Tests/SafeApp.Tests/MiscTest.cs
+++ b/Tests/SafeApp.Tests/MiscTest.cs
@@ -1,4 +1,9 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SafeApp.Core;
 using SafeApp.MockAuthBindings;
 
 namespace SafeApp.Tests
@@ -13,5 +18,41 @@ namespace SafeApp.Tests
         [Test]
         public void IsMockSafeAppBuildTest()
             => Assert.That(Session.IsMockBuild(), Is.True);
+
+        [Test]
+        public async Task SetConfigFileDirPathTest()
+            => await Session.SetConfigurationFilePathAsync(
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+
+        [Test]
+        public async Task RustLoggerTest()
+        {
+            var configPath = string.Empty;
+            Assert.That(async () => configPath = await TestUtils.InitRustLogging(), Throws.Nothing);
+            Assert.That(
+                async () =>
+                await Session.DecodeIpcMessageAsync("Some Random Invalid String"),
+                Throws.TypeOf<IpcMsgException>());
+            var fileEmpty = true;
+            for (var i = 0; i < 10; ++i)
+            {
+                await Task.Delay(1000);
+                using (var fs = new FileStream(
+                    Path.Combine(configPath, "Client.log"),
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite))
+                using (var sr = new StreamReader(fs, Encoding.Default))
+                {
+                    fileEmpty = string.IsNullOrEmpty(sr.ReadToEnd());
+                    if (!fileEmpty)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            Assert.That(fileEmpty, Is.False);
+        }
     }
 }

--- a/Tests/SafeApp.Tests/MiscTest.cs
+++ b/Tests/SafeApp.Tests/MiscTest.cs
@@ -24,6 +24,9 @@ namespace SafeApp.Tests
             => await Session.SetConfigurationFilePathAsync(
                 Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
 
+#if WIN64 && NETCOREAPP
+        [Ignore("Rust logger not working on .NET Core Windows, needs more testing locally")]
+#endif
         [Test]
         public async Task RustLoggerTest()
         {

--- a/Tests/SafeApp.Tests/log.toml
+++ b/Tests/SafeApp.Tests/log.toml
@@ -17,7 +17,7 @@ file_timestamp = false
 level = "error"
 appenders = ["async_file"] 
 
-[loggers."crust"]
+[loggers."quic-p2p"]
 level = "debug"
 
 [loggers."routing"]
@@ -37,3 +37,9 @@ level = "trace"
 
 [loggers."ffi_utils"]
 level = "trace"
+
+[loggers."safe-api"]
+level = "debug"
+
+[loggers."safe-ffi"]
+level = "debug"


### PR DESCRIPTION
- **SetConfigurationFilePathAsync** test is added to ensure the native libs has this native function available.
-  **RustLoggerTest** test is ignored on Win + .NET Core env. I'm not sure why this one is not working, will need SCL help to figure this out.
- Added the rust logging util function which can be manually called if required when running the tests locally.