### PR TITLE
Use latest native libs and remove ignore attribute for inspect and fetch tests

### DIFF
--- a/Build/NativeScriptDownloader.cake
+++ b/Build/NativeScriptDownloader.cake
@@ -1,4 +1,4 @@
-var TAG = "8a3c183";
+var TAG = "11046de";
 
 var S3_DOWNLOAD_BASE_URL = "https://safe-cli.s3.amazonaws.com/";
 var LIB_DIR_NAME = "../SafeApp.AppBindings/NativeLibs/";

--- a/Build/NativeScriptDownloader.cake
+++ b/Build/NativeScriptDownloader.cake
@@ -1,4 +1,4 @@
-var TAG = "af42208";
+var TAG = "30a8d98";
 
 var S3_DOWNLOAD_BASE_URL = "https://safe-cli.s3.amazonaws.com/";
 var LIB_DIR_NAME = "../SafeApp.AppBindings/NativeLibs/";

--- a/Build/NativeScriptDownloader.cake
+++ b/Build/NativeScriptDownloader.cake
@@ -1,4 +1,4 @@
-var TAG = "30a8d98";
+var TAG = "8a3c183";
 
 var S3_DOWNLOAD_BASE_URL = "https://safe-cli.s3.amazonaws.com/";
 var LIB_DIR_NAME = "../SafeApp.AppBindings/NativeLibs/";

--- a/Tests/SafeApp.Tests.Core/SafeApp.Tests.Core.csproj
+++ b/Tests/SafeApp.Tests.Core/SafeApp.Tests.Core.csproj
@@ -14,6 +14,10 @@
     <DefineConstants>TRACE;DEBUG;__DESKTOP__</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
+    <DefineConstants>TRACE;DEBUG;__DESKTOP__;WIN64</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\..\SafeApp.AppBindings\NativeLibs\Desktop\mock\libsafe_api.dylib" Link="libsafe_api.dylib" Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Tests/SafeApp.Tests/FetchTest.cs
+++ b/Tests/SafeApp.Tests/FetchTest.cs
@@ -5,9 +5,6 @@ using SafeApp.Core;
 namespace SafeApp.Tests
 {
     [TestFixture]
-#if __ANDROID__ || __IOS__
-    [Ignore("Fetch and Inspect API fails on Android and iOS")]
-#endif
     public class FetchTest
     {
         [OneTimeSetUp]

--- a/Tests/SafeApp.Tests/MiscTest.cs
+++ b/Tests/SafeApp.Tests/MiscTest.cs
@@ -1,4 +1,9 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SafeApp.Core;
 using SafeApp.MockAuthBindings;
 
 namespace SafeApp.Tests
@@ -13,5 +18,44 @@ namespace SafeApp.Tests
         [Test]
         public void IsMockSafeAppBuildTest()
             => Assert.That(Session.IsMockBuild(), Is.True);
+
+        [Test]
+        public async Task SetConfigFileDirPathTest()
+            => await Session.SetConfigurationFilePathAsync(
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+
+#if WIN64 && NETCOREAPP
+        [Ignore("Rust logger not working on .NET Core Windows, needs more testing locally")]
+#endif
+        [Test]
+        public async Task RustLoggerTest()
+        {
+            var configPath = string.Empty;
+            Assert.That(async () => configPath = await TestUtils.InitRustLogging(), Throws.Nothing);
+            Assert.That(
+                async () =>
+                await Session.DecodeIpcMessageAsync("Some Random Invalid String"),
+                Throws.TypeOf<IpcMsgException>());
+            var fileEmpty = true;
+            for (var i = 0; i < 10; ++i)
+            {
+                await Task.Delay(1000);
+                using (var fs = new FileStream(
+                    Path.Combine(configPath, "Client.log"),
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite))
+                using (var sr = new StreamReader(fs, Encoding.Default))
+                {
+                    fileEmpty = string.IsNullOrEmpty(sr.ReadToEnd());
+                    if (!fileEmpty)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            Assert.That(fileEmpty, Is.False);
+        }
     }
 }

--- a/Tests/SafeApp.Tests/NrsTest.cs
+++ b/Tests/SafeApp.Tests/NrsTest.cs
@@ -32,13 +32,12 @@ namespace SafeApp.Tests
             Assert.AreEqual(DataType.SafeKey, xorUrlEncoder.DataType);
             Assert.AreEqual(1, xorUrlEncoder.EncodingVersion);
             Assert.AreEqual(string.Empty, xorUrlEncoder.Path);
-            Assert.AreEqual("[]", xorUrlEncoder.SubNames);
+            Assert.IsEmpty(xorUrlEncoder.SubNames);
             Assert.AreEqual(0, xorUrlEncoder.TypeTag);
             Validate.XorName(xorUrlEncoder.XorName);
         }
 
         [Test]
-        [Ignore("Needs to be fixed. Ignoring to test the Android and iOS libs on CI.")]
         public async Task ParseAndResolveUrlTest()
         {
             var session = await TestUtils.CreateTestApp();

--- a/Tests/SafeApp.Tests/Validations.cs
+++ b/Tests/SafeApp.Tests/Validations.cs
@@ -31,11 +31,11 @@ namespace SafeApp.Tests
         public static void EnsureNullNrsContainerInfo(NrsMapContainerInfo info)
         {
             Assert.AreEqual(DataType.SafeKey, info.DataType); // since 0 is actually a data type
-            Assert.IsNull(info.NrsMap);
-            Assert.IsNull(info.PublicName);
+            Assert.IsEmpty(info.NrsMap);
+            Assert.IsEmpty(info.PublicName);
             Assert.Zero(info.TypeTag);
             Assert.Zero(info.Version); // since v 0 is actually the first version
-            Assert.IsNull(info.XorUrl);
+            Assert.IsEmpty(info.XorUrl);
             Assert.IsTrue(Enumerable.SequenceEqual(new byte[32], info.XorName));
         }
 

--- a/Tests/SafeApp.Tests/log.toml
+++ b/Tests/SafeApp.Tests/log.toml
@@ -17,7 +17,7 @@ file_timestamp = false
 level = "error"
 appenders = ["async_file"] 
 
-[loggers."crust"]
+[loggers."quic-p2p"]
 level = "debug"
 
 [loggers."routing"]
@@ -37,3 +37,9 @@ level = "trace"
 
 [loggers."ffi_utils"]
 level = "trace"
+
+[loggers."safe-api"]
+level = "debug"
+
+[loggers."safe-ffi"]
+level = "debug"


### PR DESCRIPTION
fixes: #160 
fixes: #161

- **SetConfigurationFilePathAsync** test is added to ensure the native libs has this native function available.
-  **RustLoggerTest** test is ignored on Win + .NET Core env. I'm not sure why this one is not working, will need SCL help to figure this out.
- Added the rust logging util function which can be manually called if required when running the tests locally.
