### PR TITLE
refactor/bindings: use FilesMap structs instead of json strings

### DIFF
--- a/Build/NativeScriptDownloader.cake
+++ b/Build/NativeScriptDownloader.cake
@@ -1,4 +1,4 @@
-var TAG = "11046de";
+var TAG = "a560641";
 
 var S3_DOWNLOAD_BASE_URL = "https://safe-cli.s3.amazonaws.com/";
 var LIB_DIR_NAME = "../SafeApp.AppBindings/NativeLibs/";

--- a/Tests/SafeApp.Tests/FetchTest.cs
+++ b/Tests/SafeApp.Tests/FetchTest.cs
@@ -90,6 +90,12 @@ namespace SafeApp.Tests
                         break;
                     case FilesContainer filesContainer:
                         Validate.XorName(filesContainer.XorName);
+                        Assert.NotNull(filesContainer.FilesMap);
+                        Assert.NotZero(filesContainer.FilesMap.Files.Count);
+                        Assert.NotNull(filesContainer.FilesMap.Files[0].FileMetaData);
+                        Assert.NotZero(filesContainer.FilesMap.Files[0].FileMetaData.Count);
+                        Assert.IsNotNull(filesContainer.FilesMap.Files[0].FileName);
+                        Assert.IsNotEmpty(filesContainer.FilesMap.Files[0].FileName);
                         if (expectNrs)
                             Validate.NrsContainerInfo(filesContainer.ResolvedFrom);
                         else


### PR DESCRIPTION
**Changes related to: https://github.com/maidsafe/safe-api/pull/326**

_**Note:** CI will fail as the native libs need to be updated to use the latest. Will update the PR later._